### PR TITLE
Update warning about Python.NET version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install zospy
 ### Python packages
 - [Python for .NET](http://pythonnet.github.io/) (tested with version 2.5.2)
    > **Warning**: _(Oktober 2022)_
-   Some functions of the ZOS-API seem fail with the newest available version of Pythonnet (version 3.0.0.post1), resulting in the following error: **"since Python.NET 3.0 int can not be converted to Enum implicitly."**. Therefore, the required version of pythonnet has been set to version 2.5.2 as this seems to work fine. Upon running into similar errors, please check the installed pythonnet version. We are working on a solution for this problem.
+   Some functions of the ZOS-API do not work with the newest available version of Pythonnet (version 3.0.1). See https://github.com/MREYE-LUMC/ZOSPy/issues/9 for more information. Therefore, the required version of pythonnet has been set to version 2.5.2 as this seems to work fine. Upon running into similar errors, please check the installed pythonnet version. We are working on a solution for this problem.
 
 - [pandas](https://pandas.pydata.org/)
 - [NumPy](https://numpy.org/)


### PR DESCRIPTION
The current warning about Python.NET compatibility issues only points to Enum to Int conversions, which to the best of my knowledge has already been fixed or otherwise is quite easy to fix. I updated the warning to provide more information about other issues that can't be fixed in this library.