### PR TITLE
Add a Publish to TestPyPI action

### DIFF
--- a/.github/workflows/python-test-publish.yml
+++ b/.github/workflows/python-test-publish.yml
@@ -1,0 +1,40 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish to TestPyPI
+
+on:
+  # Only allow manual triggering
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.TESTPYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/

--- a/.github/workflows/python-test-publish.yml
+++ b/.github/workflows/python-test-publish.yml
@@ -37,4 +37,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.TESTPYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Adds an action that publishes ZOSPy to TestPyPI. This action should be triggered manually (at least for the time being).