### PR TITLE
Adding function equivalent to ZPL numeric function OBJC($A) in zospy.functions.nce

### DIFF
--- a/tests/functions/__init__.py
+++ b/tests/functions/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for Zemax OpticStudio functions."""

--- a/tests/functions/test_lde.py
+++ b/tests/functions/test_lde.py
@@ -3,27 +3,26 @@ import pytest
 from zospy.functions.lde import find_surface_by_comment
 
 
-class TestLDEFunctions:
-    @pytest.mark.parametrize(
-        "comment,case_sensitive,expected_indices",
-        [
-            ("Abcd", True, [0]),
-            ("Abcd", False, [0, 1, 2, 3]),
-            ("ABcd", True, [1]),
-            ("ABCD", True, []),
-            ("ABCD", False, [0, 1, 2, 3]),
-            ("efgh", True, []),
-            ("efgh", False, []),
-        ],
-    )
-    def test_can_find_surface_by_comment(self, simple_system, comment, case_sensitive, expected_indices):
-        simple_system.LDE.GetSurfaceAt(0).Comment = "Abcd"
-        simple_system.LDE.GetSurfaceAt(1).Comment = "ABcd"
-        simple_system.LDE.GetSurfaceAt(2).Comment = "ABCd"
-        simple_system.LDE.GetSurfaceAt(3).Comment = "ABCd"
+@pytest.mark.parametrize(
+    "comment,case_sensitive,expected_indices",
+    [
+        ("Abcd", True, [0]),
+        ("Abcd", False, [0, 1, 2, 3]),
+        ("ABcd", True, [1]),
+        ("ABCD", True, []),
+        ("ABCD", False, [0, 1, 2, 3]),
+        ("efgh", True, []),
+        ("efgh", False, []),
+    ],
+)
+def test_can_find_surface_by_comment(simple_system, comment, case_sensitive, expected_indices):
+    simple_system.LDE.GetSurfaceAt(0).Comment = "Abcd"
+    simple_system.LDE.GetSurfaceAt(1).Comment = "ABcd"
+    simple_system.LDE.GetSurfaceAt(2).Comment = "ABCd"
+    simple_system.LDE.GetSurfaceAt(3).Comment = "ABCd"
 
-        result = find_surface_by_comment(simple_system.LDE, comment=comment, case_sensitive=case_sensitive)
+    result = find_surface_by_comment(simple_system.LDE, comment=comment, case_sensitive=case_sensitive)
 
-        indices = [surface.RowIndex for surface in result]
+    indices = [surface.RowIndex for surface in result]
 
-        assert indices == expected_indices
+    assert indices == expected_indices

--- a/tests/functions/test_lde.py
+++ b/tests/functions/test_lde.py
@@ -6,7 +6,7 @@ from zospy.functions.lde import find_surface_by_comment
 @pytest.mark.parametrize(
     "comment,case_sensitive,expected_indices",
     [
-        ("Abcd", True, [0]),
+        ("Abcd", True, [0]), # When using .SurfaceNumber, the returned value matches the LDE numbering (starting at 0)
         ("Abcd", False, [0, 1, 2, 3]),
         ("ABcd", True, [1]),
         ("ABCD", True, []),
@@ -23,6 +23,6 @@ def test_can_find_surface_by_comment(simple_system, comment, case_sensitive, exp
 
     result = find_surface_by_comment(simple_system.LDE, comment=comment, case_sensitive=case_sensitive)
 
-    indices = [surface.RowIndex for surface in result]
+    indices = [surface.SurfaceNumber for surface in result]
 
     assert indices == expected_indices

--- a/tests/functions/test_lde.py
+++ b/tests/functions/test_lde.py
@@ -1,0 +1,29 @@
+import pytest
+
+from zospy.functions.lde import find_surface_by_comment
+
+
+class TestLDEFunctions:
+    @pytest.mark.parametrize(
+        "comment,case_sensitive,expected_indices",
+        [
+            ("Abcd", True, [0]),
+            ("Abcd", False, [0, 1, 2, 3]),
+            ("ABcd", True, [1]),
+            ("ABCD", True, []),
+            ("ABCD", False, [0, 1, 2, 3]),
+            ("efgh", True, []),
+            ("efgh", False, []),
+        ],
+    )
+    def test_can_find_surface_by_comment(self, simple_system, comment, case_sensitive, expected_indices):
+        simple_system.LDE.GetSurfaceAt(0).Comment = "Abcd"
+        simple_system.LDE.GetSurfaceAt(1).Comment = "ABcd"
+        simple_system.LDE.GetSurfaceAt(2).Comment = "ABCd"
+        simple_system.LDE.GetSurfaceAt(3).Comment = "ABCd"
+
+        result = find_surface_by_comment(simple_system.LDE, comment=comment, case_sensitive=case_sensitive)
+
+        indices = [surface.RowIndex for surface in result]
+
+        assert indices == expected_indices

--- a/tests/functions/test_lde.py
+++ b/tests/functions/test_lde.py
@@ -6,7 +6,7 @@ from zospy.functions.lde import find_surface_by_comment
 @pytest.mark.parametrize(
     "comment,case_sensitive,expected_indices",
     [
-        ("Abcd", True, [0]), # When using .SurfaceNumber, the returned value matches the LDE numbering (starting at 0)
+        ("Abcd", True, [0]),  # When using .SurfaceNumber, the returned value matches the LDE numbering (starting at 0)
         ("Abcd", False, [0, 1, 2, 3]),
         ("ABcd", True, [1]),
         ("ABCD", True, []),

--- a/tests/functions/test_nce.py
+++ b/tests/functions/test_nce.py
@@ -1,0 +1,27 @@
+import pytest
+
+from zospy.functions.nce import find_object_by_comment
+
+
+@pytest.mark.parametrize(
+    "comment,case_sensitive,expected_indices",
+    [
+        ("Abc", True, [1]),  # When using .ObjectNumber, the returned value matches the NCE numbering (starting at 1)
+        ("Abc", False, [1, 2, 3]),
+        ("ABc", True, [2, 3]),
+        ("ABC", True, []),
+        ("ABC", False, [1, 2, 3]),
+        ("efg", True, []),
+        ("efg", False, []),
+    ],
+)
+def test_can_find_object_by_comment(nsc_simple_system, comment, case_sensitive, expected_indices):
+    nsc_simple_system.NCE.GetObjectAt(1).Comment = "Abc"
+    nsc_simple_system.NCE.GetObjectAt(2).Comment = "ABc"
+    nsc_simple_system.NCE.GetObjectAt(3).Comment = "ABc"
+
+    result = find_object_by_comment(nsc_simple_system.NCE, comment=comment, case_sensitive=case_sensitive)
+
+    indices = [obj.ObjectNumber for obj in result]
+
+    assert indices == expected_indices

--- a/zospy/functions/lde.py
+++ b/zospy/functions/lde.py
@@ -74,7 +74,7 @@ def surface_change_type(surface: _ZOSAPI.Editors.LDE.ILDERow, new_type: constant
 
 
 def find_surface_by_comment(
-    lde: _ZOSAPI.Editors.LDE, comment: str, case_sensitive: bool = False
+    lde: _ZOSAPI.Editors.LDE, comment: str, case_sensitive: bool = True
 ) -> list[_ZOSAPI.Editors.LDE.ILDERow]:
     """Returns a list of surfaces from the LDE that have the supplied string as Comment.
 
@@ -85,9 +85,9 @@ def find_surface_by_comment(
     lde: ZOSAPI.Editors.LDE
         The Lens Data Editor (LDE)
     comment: str
-        String that is searched for in the Comment column of the NCE.
-    case_sensitive: bool=False
-        Flag that specifies whether the search is case-sensitive or not. Defaults to False.
+        String that is searched for in the Comment column of the LDE.
+    case_sensitive: bool
+        Flag that specifies whether the search is case-sensitive or not. Defaults to True.
 
     Returns
     -------

--- a/zospy/functions/lde.py
+++ b/zospy/functions/lde.py
@@ -91,7 +91,7 @@ def find_surface_by_comment(
 
     Returns
     -------
-    list[_ZOSAPI.Editors.LDE.ILDERow]
+    list[ZOSAPI.Editors.LDE.ILDERow]
         A list of surfaces in the LDE that have a Comment column value which matches the supplied comment argument.
 
     Examples

--- a/zospy/functions/lde.py
+++ b/zospy/functions/lde.py
@@ -71,3 +71,67 @@ def surface_change_type(surface: _ZOSAPI.Editors.LDE.ILDERow, new_type: constant
     # Apply
     new_surface_type_settings = surface.GetSurfaceTypeSettings(new_type)
     surface.ChangeType(new_surface_type_settings)
+
+
+def find_surface_by_comment(
+    lde: _ZOSAPI.Editors.LDE, comment: str, case_sensitive: bool = False
+) -> list[_ZOSAPI.Editors.LDE.ILDERow]:
+    """Returns a list of surfaces from the LDE that have the supplied string as Comment.
+
+    In case of multiple matches, the surfaces are returned in ascending order.
+
+    Parameters
+    ----------
+    lde: ZOSAPI.Editors.LDE
+        The Lens Data Editor (LDE)
+    comment: str
+        String that is searched for in the Comment column of the NCE.
+    case_sensitive: bool=False
+        Flag that specifies whether the search is case-sensitive or not. Defaults to False.
+
+    Returns
+    -------
+    list[_ZOSAPI.Editors.LDE.ILDERow]
+        A list of surfaces in the LDE that have a Comment column value which matches the supplied comment argument.
+
+    Examples
+    --------
+    >>> import zospy as zp
+    >>> zos = zp.ZOS()
+    >>> zos.wakeup()
+    >>> zos.connect_as_extension()
+    >>> oss = zos.get_primary_system()
+    >>> newobj1 = oss.LDE.GetSurfaceAt(0)
+    >>> newobj1.Comment = 'aa'
+    >>> newobj2 = oss.LDE.GetSurfaceAt(1)
+    >>> newobj2.Comment = 'bb'
+    >>> newobj3 = oss.LDE.GetSurfaceAt(2)
+    >>> newobj3.Comment = 'aA'
+    >>> zp.functions.lde.find_surface_by_comment(oss.LDE, 'aa')
+    """
+    # Is the search case-sensitive?
+    if not case_sensitive:
+        # If the search is NOT case-sensitive put comment argument in all small letters
+        comment = comment.lower()
+
+    # Initialize list of return indexes corresponding to LDE rows with matched Comment column
+
+    return_indices = []
+    # Loop over the objects and check the comments
+
+    for surface_index in range(lde.NumberOfSurfaces):
+        # Retrieve current object comment
+        surface = lde.GetSurfaceAt(surface_index)
+        surface_comment = surface.Comment
+
+        # Is the search case-sensitive?
+        if not case_sensitive:
+            # If the search is NOT case-sensitive put current object comment in all small letters
+            surface_comment = surface_comment.lower()
+
+        # If the comment matches, store the corresponding object index
+        if comment == surface_comment:
+            return_indices.append(surface)
+
+    # Return list of matched inices
+    return return_indices

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -54,7 +54,18 @@ def find_object_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: 
 
     Examples
     ----------
-    >>> To be added
+    >>> import zospy as zp
+    >>> zos = zp.ZOS()
+    >>> zos.connect_as_extension()
+    >>> oss = zos.get_primary_system()
+    >>> oss.make_nonsequential()
+    >>> newobj1 = oss.NCE.InsertNewObjectAt(0)
+    >>> newobj1.Comment = 'aa'
+    >>> newobj2 = oss.NCE.InsertNewObjectAt(0)
+    >>> newobj2.Comment = 'bb'
+    >>> newobj3 = oss.NCE.InsertNewObjectAt(0)
+    >>> newobj3.Comment = 'aA'
+    >>> find_object_comment(oss.NCE, 'aa')
     """
     
     # Number of objects in the NCE

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -33,7 +33,7 @@ def object_change_type(obj: _ZOSAPI.Editors.NCE.INCERow, new_type: constants.Edi
     new_surface_type_settings = obj.GetObjectTypeSettings(new_type)
     obj.ChangeType(new_surface_type_settings)
 
-def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: bool=False) -> list[_ZOSAPI.Editors.NCE.INCERow]:
+def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: bool=True) -> list[_ZOSAPI.Editors.NCE.INCERow]:
     """Returns a list of objects, in ascending order from the NCE, that have a Comment column value which matches
     the comment string argument.
     
@@ -44,11 +44,11 @@ def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitiv
     comment: str
         String that is searched for in the Comment column of the NCE.
     case_sensitive: bool=False
-        Flag that specifies whether the search is case-sensitive or not (default value).
+        Flag that specifies whether the search is case-sensitive (default value) or not.
 
     Returns
     ----------
-    list[_ZOSAPI.Editors.NCE.INCERow]
+    list[ZOSAPI.Editors.NCE.INCERow]
         A list of object in the NCE that have a Comment column value which matches the comment argument.
 
     Examples

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -33,9 +33,10 @@ def object_change_type(obj: _ZOSAPI.Editors.NCE.INCERow, new_type: constants.Edi
     new_surface_type_settings = obj.GetObjectTypeSettings(new_type)
     obj.ChangeType(new_surface_type_settings)
 
-def find_object_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: bool=False) -> list[int] | int:
-    """Function equivalent to ZPL numeric function OBJC($A).
-
+def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: bool=False) -> list[_ZOSAPI.Editors.NCE.INCERow]:
+    """Returns a list of objects, in ascending order from the NCE, that have a Comment column value which matches
+    the comment string argument.
+    
     Parameters
     ----------
     nce: ZOSAPI.Editors.NCE
@@ -43,14 +44,12 @@ def find_object_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: 
     comment: str
         String that is searched for in the Comment column of the NCE.
     case_sensitive: bool=False
-        Flag that specifies whether the search is case-sensitive or not.
-
+        Flag that specifies whether the search is case-sensitive or not (default value).
 
     Returns
     ----------
-    A list of integer indices corresponding to the rows of the NCE
-    that had a matching comment, or -1 if no correspondance was
-    found.
+    list[_ZOSAPI.Editors.NCE.INCERow]
+        A list of object in the NCE that have a Comment column value which matches the comment argument.
 
     Examples
     ----------
@@ -65,7 +64,7 @@ def find_object_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: 
     >>> newobj2.Comment = 'bb'
     >>> newobj3 = oss.NCE.InsertNewObjectAt(0)
     >>> newobj3.Comment = 'aA'
-    >>> find_object_comment(oss.NCE, 'aa')
+    >>> find_object_by_comment(oss.NCE, 'aa')
     """
     
     # Number of objects in the NCE
@@ -73,32 +72,28 @@ def find_object_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: 
 
     # Is the search case-sensitive?
     if not case_sensitive:
-        # If the search is NOT case-sensitive put 
-        # comment argument in all small letters
+        # If the search is NOT case-sensitive put comment argument in all small letters
         comment = comment.lower()
 
-    # Initialize list of return indexes corresponding
-    # to NCE rows with matched Comment column
-    return_indices = []
+    # Initialize list of objects with matching comment
+    matching_objects = []
 
-    # Loop over the objects and check the comments
+    # Loop over the objects in the NCE and check if their comment matches
     for object_index in range(1, number_of_objects+1):
+        # Retrieve current object
+        current_object = nce.GetObjectAt(object_index)
+        
         # Retrieve current object comment
-        object_comment = nce.GetObjectAt(object_index).Comment
+        object_comment = current_object.Comment
 
         # Is the search case-sensitive?
         if not case_sensitive:
-            # If the search is NOT case-sensitive put 
-            # current object comment in all small letters
+            # If the search is NOT case-sensitive put current object comment in all small letters
             object_comment = object_comment.lower()           
 
-        # If the comment matches, store the corresponding object index
+        # If the comment matches, append the corresponding object to the return list
         if comment == object_comment:
-            return_indices.append(object_index)
+            matching_objects.append(current_object)
 
-    # If no match are found set the return list to -1
-    if not return_indices:
-        return_indices = -1
-
-    # Return list of matched inices
-    return return_indices
+    # Return list of objects with matching comment
+    return matching_objects

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from zospy.api import _ZOSAPI, constants
 
-
 def object_change_type(obj: _ZOSAPI.Editors.NCE.INCERow, new_type: constants.Editors.NCE.ObjectType | str):
     """Simple function to change the object type in the NCE.
 
@@ -33,3 +32,62 @@ def object_change_type(obj: _ZOSAPI.Editors.NCE.INCERow, new_type: constants.Edi
     # Apply
     new_surface_type_settings = obj.GetObjectTypeSettings(new_type)
     obj.ChangeType(new_surface_type_settings)
+
+def find_object_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: bool=False) -> list[int] | int:
+    """Function equivalent to ZPL numeric function OBJC($A).
+
+    Parameters
+    ----------
+    nce: ZOSAPI.Editors.NCE
+        The Non-sequential Component Editor (NCE).
+    comment: str
+        String that is searched for in the Comment column of the NCE.
+    case_sensitive: bool=False
+        Flag that specifies whether the search is case-sensitive or not.
+
+
+    Returns
+    ----------
+    A list of integer indices corresponding to the rows of the NCE
+    that had a matching comment, or -1 if no correspondance was
+    found.
+
+    Examples
+    ----------
+    >>> To be added
+    """
+    
+    # Number of objects in the NCE
+    number_of_objects = nce.NumberOfObjects
+
+    # Is the search case-sensitive?
+    if not case_sensitive:
+        # If the search is NOT case-sensitive put 
+        # comment argument in all small letters
+        comment = comment.lower()
+
+    # Initialize list of return indexes corresponding
+    # to NCE rows with matched Comment column
+    return_indices = []
+
+    # Loop over the objects and check the comments
+    for object_index in range(1, number_of_objects+1):
+        # Retrieve current object comment
+        object_comment = nce.GetObjectAt(object_index).Comment
+
+        # Is the search case-sensitive?
+        if not case_sensitive:
+            # If the search is NOT case-sensitive put 
+            # current object comment in all small letters
+            object_comment = object_comment.lower()           
+
+        # If the comment matches, store the corresponding object index
+        if comment == object_comment:
+            return_indices.append(object_index)
+
+    # If no match are found set the return list to -1
+    if not return_indices:
+        return_indices = -1
+
+    # Return list of matched inices
+    return return_indices

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -24,7 +24,7 @@ def object_change_type(obj: _ZOSAPI.Editors.NCE.INCERow, new_type: constants.Edi
     >>> zos.connect_as_extension()
     >>> oss = zos.get_primary_system()
     >>> oss.make_nonsequential()
-    >>> newobj = oss.NCE.InsertNewObjectAt(0)
+    >>> newobj = oss.NCE.InsertNewObjectAt(1)
     >>> object_change_type(newobj, zp.constants.Editors.NCE.ObjectType.StandardLens)
     """
     new_type = constants.process_constant(constants.Editors.NCE.ObjectType, new_type)
@@ -58,11 +58,11 @@ def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitiv
     >>> zos.connect_as_extension()
     >>> oss = zos.get_primary_system()
     >>> oss.make_nonsequential()
-    >>> newobj1 = oss.NCE.InsertNewObjectAt(0)
+    >>> newobj1 = oss.NCE.InsertNewObjectAt(1)
     >>> newobj1.Comment = 'aa'
-    >>> newobj2 = oss.NCE.InsertNewObjectAt(0)
+    >>> newobj2 = oss.NCE.InsertNewObjectAt(1)
     >>> newobj2.Comment = 'bb'
-    >>> newobj3 = oss.NCE.InsertNewObjectAt(0)
+    >>> newobj3 = oss.NCE.InsertNewObjectAt(1)
     >>> newobj3.Comment = 'aA'
     >>> find_object_by_comment(oss.NCE, 'aa')
     """

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from zospy.api import _ZOSAPI, constants
 
+
 def object_change_type(obj: _ZOSAPI.Editors.NCE.INCERow, new_type: constants.Editors.NCE.ObjectType | str):
     """Simple function to change the object type in the NCE.
 
@@ -33,10 +34,14 @@ def object_change_type(obj: _ZOSAPI.Editors.NCE.INCERow, new_type: constants.Edi
     new_surface_type_settings = obj.GetObjectTypeSettings(new_type)
     obj.ChangeType(new_surface_type_settings)
 
-def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: bool=True) -> list[_ZOSAPI.Editors.NCE.INCERow]:
-    """Returns a list of objects, in ascending order from the NCE, that have a Comment column value which matches
-    the comment string argument.
-    
+
+def find_object_by_comment(
+    nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitive: bool = True
+) -> list[_ZOSAPI.Editors.NCE.INCERow]:
+    """Returns a list of objects from the NCE that have the supplied string as Comment.
+
+    In case of multiple matches, the objects are returned in ascending order.
+
     Parameters
     ----------
     nce: ZOSAPI.Editors.NCE
@@ -47,12 +52,12 @@ def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitiv
         Flag that specifies whether the search is case-sensitive (default value) or not.
 
     Returns
-    ----------
+    -------
     list[ZOSAPI.Editors.NCE.INCERow]
         A list of object in the NCE that have a Comment column value which matches the comment argument.
 
     Examples
-    ----------
+    --------
     >>> import zospy as zp
     >>> zos = zp.ZOS()
     >>> zos.connect_as_extension()
@@ -66,7 +71,6 @@ def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitiv
     >>> newobj3.Comment = 'aA'
     >>> find_object_by_comment(oss.NCE, 'aa')
     """
-    
     # Number of objects in the NCE
     number_of_objects = nce.NumberOfObjects
 
@@ -79,17 +83,17 @@ def find_object_by_comment(nce: _ZOSAPI.Editors.NCE, comment: str, case_sensitiv
     matching_objects = []
 
     # Loop over the objects in the NCE and check if their comment matches
-    for object_index in range(1, number_of_objects+1):
+    for object_index in range(1, number_of_objects + 1):
         # Retrieve current object
         current_object = nce.GetObjectAt(object_index)
-        
+
         # Retrieve current object comment
         object_comment = current_object.Comment
 
         # Is the search case-sensitive?
         if not case_sensitive:
             # If the search is NOT case-sensitive put current object comment in all small letters
-            object_comment = object_comment.lower()           
+            object_comment = object_comment.lower()
 
         # If the comment matches, append the corresponding object to the return list
         if comment == object_comment:


### PR DESCRIPTION
Hi Jan-Willem, and team,


This refers to [my answer in the Zemax Community](https://community.zemax.com/zos-api-12/is-there-a-zos-api-equivalent-to-the-zpl-objc-a-4170) about a ZOSAPI function equivalent to ZPL numeric function OBJC($A).

I somehow didn't manage to run ZOSPy with 2023 R1.03 though, so I couldn't test the example I wrote in the docstring.

I also don't know about unit testing (I'm not a software engineer) but I'm happy to help if you explain me how to do this kind of stuff.

Take care,


David