### PR TITLE
Add actions for linting and formatting

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,20 @@
+name: Run tox environments
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox
+    - name: Test with tox
+      run: tox -m github-actions

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ labels =
     test-extension = py3{8,9,10,11}-extension
     test-standalone = py3{8,9,10,11}-standalone
     extension = format,lint,py3{9,10,11}-extension
+    github-actions = format,lint
 
 # Default environments that are run without further specification
 env_list =


### PR DESCRIPTION
Automatically run the format and lint tox environments on each push and PR.
This doesn't update the code, but indicates if contributions meet our standards.

It would be nice to run the unit tests as well, but this is not feasible, due to our dependency on OpticStudio.