### PR TITLE
Updated licence ID to adhere to the zenodo api

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -31,7 +31,7 @@
   ],
 
   "upload_type": "software",
-  "license": "GNU General Public License v3.0",
+  "license": "GPL-3.0",
   "access_right": "open",
 
   "keywords": ["Ray tracing", "OpticStudio", "Zemax"]


### PR DESCRIPTION
Zenodo is currently giving an error for new versions due to the licence field in .zenodo.json. According to the help desk, this field has to be set to one of the id's available in the Zenodo API. For our licence ["GPL-3.0"](https://zenodo.org/api/licenses/?page=257&size=1) seems to be the correct ID.