### PR TITLE
Use a clearer error message when a second ZOS instance is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update the error message in `zospy.ZOS` to explain why only a single instance of `ZOS` is allowed (#24)
+
 ### Deprecated
 
 ### Removed

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -294,7 +294,7 @@ class ZOS:
             # number of ZOS instances
             raise ValueError(
                 "Cannot have more than one active ZOS instance.\n\n"
-                "Since OpticStudio limits the number of connections to the ZOS-API to 1, only a single ZOS instance"
+                "Since OpticStudio limits the number of connections to the ZOS-API to 1, only a single ZOS instance "
                 "is allowed. Re-use the existing instance, or delete the existing instance prior to initializing a "
                 "new one."
             )

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -292,7 +292,12 @@ class ZOS:
         if len(cls._instances) >= 1:
             # As the number of applications within runtime is limited to 1 by Zemax, it is logical to also limit the
             # number of ZOS instances
-            raise ValueError("Cannot have more than one active ZOS instance")
+            raise ValueError(
+                "Cannot have more than one active ZOS instance.\n\n"
+                "Since OpticStudio limits the number of connections to the ZOS-API to 1, only a single ZOS instance"
+                "is allowed. Re-use the existing instance, or delete the existing instance prior to initializing a "
+                "new one."
+            )
 
         instance = super(ZOS, cls).__new__(cls, *args, **kwargs)
 


### PR DESCRIPTION
Currently, when a second instance of `zospy.ZOS` is created, an exception is thrown which states that only a single instance of `ZOS` can be initialized. The message doesn't state _why_ the number of instances is limited to one, and why the exception is raised. As seen in #19, this can be confusing.

I updated the error message to include more information about the reason of this limitation and why the exception was thrown.