### PR TITLE
Explain deviations from SemVer in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html),
+with one exception: small features that only simplify access to certain parts of the
+ZOS-API can also be added in patch releases.
 
 ## [Unreleased]
 


### PR DESCRIPTION
The changelog states that we adhere to Semantic Versioning, which isn't completely true since we allow certain features to be added in patch releases. It is probably good to document this explicitly. This information has been added to CHANGELOG.md.