### PR TITLE
Initialize with fewer lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-markers = ["must_pass: test must pass, otherwise all other tests will be skipped"]
+markers = [
+    "must_pass: test must pass, otherwise all other tests will be skipped",
+    "require_mode: requires the specified connection mode, otherwise the test will be skipped"
+]
 
 [tool.mypy]
 files = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,14 @@ def connection_mode(request):
     return "extension" if request.config.getoption("--extension") else "standalone"
 
 
+@pytest.fixture(autouse=True)
+def skip_by_connection_mode(request, connection_mode):
+    if request.node.get_closest_marker("require_mode"):
+        required_mode = request.node.get_closest_marker("require_mode").args[0]
+        if required_mode != connection_mode:
+            pytest.skip(f"Test is only applicable in {required_mode} mode.")
+
+
 @pytest.fixture(scope="session")
 def legacy_connection_setup(request):
     return request.config.getoption("--legacy-connection-setup")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,13 +36,26 @@ def system_save_file(request):
 @pytest.fixture(scope="session")
 def zos() -> zp.ZOS:
     zos = zp.ZOS()
-    zos.wakeup()
 
     return zos
 
 
 @pytest.fixture
 def oss(zos: zp.ZOS, connection_mode) -> zp.zpcore.OpticStudioSystem:
+    if connection_mode == "extension":
+        oss = zos.connect_as_extension(return_primary_system=True)
+    else:
+        oss = zos.create_new_application(return_primary_system=True)
+
+    yield oss
+
+    # Close the system
+    if zos.Connection.IsAlive:
+        zos.Application.CloseApplication()
+
+
+@pytest.fixture
+def oss_legacy(zos: zp.ZOS, connection_mode) -> zp.zpcore.OpticStudioSystem:
     if connection_mode == "extension":
         connected = zos.connect_as_extension()
     else:

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -3,9 +3,9 @@ import pytest
 
 @pytest.mark.must_pass
 @pytest.mark.parametrize(
-        "oss_fixture",
-        ['oss_legacy', 'oss'],
-    )
+    "oss_fixture",
+    ["oss_legacy", "oss"],
+)
 def test_can_connect(oss_fixture, request):
     oss = request.getfixturevalue(oss_fixture)
     assert oss._System is not None

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -1,4 +1,66 @@
+from types import SimpleNamespace
+
 import pytest
+
+import zospy as zp
+
+
+def patch_zos(zos: zp.ZOS, monkeypatch: pytest.MonkeyPatch):
+    patch_application = SimpleNamespace(IsValidLicenseForAPI=False)
+    patch_connection = SimpleNamespace(
+        IsAlive=False,
+        ConnectAsExtension=lambda n: patch_application,
+        CreateNewApplication=lambda: patch_application
+    )
+
+    def patch_assign_connection(self: zp.ZOS):
+        self.Connection = patch_connection
+
+    # Patch ZOS class so ZOS.Application.IsValidLicenseForAPI is False
+    monkeypatch.setattr(zos, "_assign_connection", patch_assign_connection.__get__(zos, zp.ZOS))
+    # All attributes need to be patched explicitly, otherwise they won't be restored
+    monkeypatch.setattr(zos, "Application", patch_application)
+    monkeypatch.setattr(zos, "Connection", patch_connection)
+
+
+@pytest.mark.require_mode("extension")
+def test_connect_as_extension_without_valid_license_raises_exception(zos, monkeypatch):
+    patch_zos(zos, monkeypatch)
+
+    with pytest.raises(ConnectionRefusedError):
+        zos.connect_as_extension(return_primary_system=True)
+
+
+@pytest.mark.require_mode("extension")
+def test_connect_as_extension_without_valid_license_returns_false(zos, monkeypatch):
+    patch_zos(zos, monkeypatch)
+
+    assert zos.connect_as_extension() is False
+
+
+@pytest.mark.require_mode("extension")
+def test_connect_as_extension_with_valid_license_returns_true(zos, monkeypatch):
+    assert zos.connect_as_extension() is True
+
+
+@pytest.mark.require_mode("standalone")
+def test_create_new_application_without_valid_license_raises_exception(zos, monkeypatch):
+    patch_zos(zos, monkeypatch)
+
+    with pytest.raises(ConnectionRefusedError):
+        zos.create_new_application(return_primary_system=True)
+
+
+@pytest.mark.require_mode("standalone")
+def test_create_new_application_without_valid_license_returns_false(zos, monkeypatch):
+    patch_zos(zos, monkeypatch)
+
+    assert zos.create_new_application() is False
+
+
+@pytest.mark.require_mode("standalone")
+def test_create_new_application_with_valid_license_returns_false(zos, monkeypatch):
+    assert zos.create_new_application() is True
 
 
 @pytest.mark.must_pass
@@ -37,19 +99,15 @@ def test_get_system(zos, oss, connection_mode):
     assert system.SystemID == oss.SystemID
 
 
+@pytest.mark.require_mode("standalone")
 def test_create_new_system(zos, oss, connection_mode):
-    if connection_mode == "extension":
-        pytest.skip("Test is only applicable in standalone mode")
-
     new_system = zos.create_new_system()
 
     assert zos.Application.NumberOfOpticalSystems == 2
     assert oss.SystemID != new_system.SystemID
 
 
+@pytest.mark.require_mode("extension")
 def test_create_new_system_raises_valueerror(zos, simple_system, connection_mode):
-    if connection_mode == "standalone":
-        pytest.skip("Test is only applicable in extension mode")
-
     with pytest.raises(ValueError):
         zos.create_new_system()

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -2,12 +2,7 @@ import pytest
 
 
 @pytest.mark.must_pass
-@pytest.mark.parametrize(
-    "oss_fixture",
-    ["oss_legacy", "oss"],
-)
-def test_can_connect(oss_fixture, request):
-    oss = request.getfixturevalue(oss_fixture)
+def test_can_connect(oss):
     assert oss._System is not None
 
 

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -8,9 +8,7 @@ import zospy as zp
 def patch_zos(zos: zp.ZOS, monkeypatch: pytest.MonkeyPatch):
     patch_application = SimpleNamespace(IsValidLicenseForAPI=False)
     patch_connection = SimpleNamespace(
-        IsAlive=False,
-        ConnectAsExtension=lambda n: patch_application,
-        CreateNewApplication=lambda: patch_application
+        IsAlive=False, ConnectAsExtension=lambda n: patch_application, CreateNewApplication=lambda: patch_application
     )
 
     def patch_assign_connection(self: zp.ZOS):
@@ -42,6 +40,9 @@ def test_connect_as_extension_without_valid_license_returns_false(zos, monkeypat
 def test_connect_as_extension_with_valid_license_returns_true(zos, monkeypatch):
     assert zos.connect_as_extension() is True
 
+    # Close the connection
+    zos.Application.CloseApplication()
+
 
 @pytest.mark.require_mode("standalone")
 def test_create_new_application_without_valid_license_raises_exception(zos, monkeypatch):
@@ -61,6 +62,9 @@ def test_create_new_application_without_valid_license_returns_false(zos, monkeyp
 @pytest.mark.require_mode("standalone")
 def test_create_new_application_with_valid_license_returns_false(zos, monkeypatch):
     assert zos.create_new_application() is True
+
+    # Close the connection
+    zos.Application.CloseApplication()
 
 
 @pytest.mark.must_pass

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -2,7 +2,12 @@ import pytest
 
 
 @pytest.mark.must_pass
-def test_can_connect(oss):
+@pytest.mark.parametrize(
+        "oss_fixture",
+        ['oss_legacy', 'oss'],
+    )
+def test_can_connect(oss_fixture, request):
+    oss = request.getfixturevalue(oss_fixture)
     assert oss._System is not None
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,11 @@ labels =
 env_list =
     format
     lint
+    py39-standalone-legacy-zpcoreonly
     py39-standalone
+    py310-standalone-legacy-zpcoreonly
     py310-standalone
+    py311-standalone-legacy-zpcoreonly
     py311-standalone
 
 [testenv]
@@ -21,6 +24,11 @@ deps = [test]
 [testenv:py3{8,9,10,11}-extension]
 description = run unit tests on specific Python versions in extension mode
 commands = pytest tests --extension {posargs}
+
+[testenv:py3{8,9,10,11}-standalone-legacy-zpcoreonly]
+description = run unit tests on specific Python versions in standalone mode with a legacy connection
+passenv = *
+commands = pytest tests/test_zpcore.py --legacy-connection-setup {posargs}
 
 [testenv:py3{8,9,10,11}-standalone]
 description = run unit tests on specific Python versions in standalone mode

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -466,14 +466,7 @@ class ZOS:
             return self.get_primary_system()
             
         return True
-            logger.critical("OpticStudio Licence is not valid for API, connection not established")
-            raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
-            return False
-        else:
-            if not return_primary_system:
-                return True
-            else:
-                return self.get_primary_system()
+
 
     def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
@@ -500,13 +493,16 @@ class ZOS:
 
         if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
-            raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
+            
+            if return_primary_system:
+                raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
+            
             return False
-        else:
-            if not return_primary_system:
-                return True
-            else:
-                return self.get_primary_system()
+        
+        if return_primary_system:
+            return self.get_primary_system()
+            
+        return True
 
     def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -413,10 +413,12 @@ class ZOS:
         if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
             raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
-            logger.critical("OpticStudio Licence is not valid for API, connection not established")
-
-        
-        return self.get_primary_system()
+            return False
+        else:
+            if not return_primary_system:
+                return True
+            else
+                return self.get_primary_system()
     
     def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
@@ -443,10 +445,13 @@ class ZOS:
 
         if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
-
-        assert self.Application.IsValidLicenseForAPI, "OpticStudio Licence is not valid for API, connection not established"
-        
-        return self.get_primary_system()
+            raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
+            return False
+        else:
+            if not return_primary_system:
+                return True
+            else
+                return self.get_primary_system()
  
     def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -296,7 +296,7 @@ class ZOS:
 
     _instances = set()
 
-    def __new__(cls, preload: bool = False, zosapi_nethelper: str = None, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):
         if len(cls._instances) >= 1:
             # As the number of applications within runtime is limited to 1 by Zemax, it is logical to also limit the
             # number of ZOS instances
@@ -307,7 +307,7 @@ class ZOS:
                 "new one."
             )
 
-        instance = super(ZOS, cls).__new__(cls, *args, **kwargs)
+        instance = super(ZOS, cls).__new__(cls)
 
         return instance
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -318,6 +318,8 @@ class ZOS:
 
         logger.info("ZOS instance initialized")
 
+        self.wakeup()
+
     def wakeup(self, preload: bool = False, zosapi_nethelper: str = None):
         """Wakes the zosapi instance.
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -407,7 +407,6 @@ class ZOS:
             raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
 
-        assert self.Application.IsValidLicenseForAPI, "OpticStudio Licence is not valid for API, connection not established"
         
         return self.get_primary_system()
     

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -263,33 +263,56 @@ class ZOS:
     """A Communication instance for Zemax OpticStudio.
 
     This class can be used to establish a link between Python and Zemax OpticStudio through .NET,
-    and control OpticStudio. The connection is established as following:
-
-    Simple:
-    1. self.wakeup().
-    2. self.create_new_session() or self.connect_as_extension().
-    3. self.get_primary_system()
-
-    Advanced:
-    1. self._load_zos_dlls()
-    2. self._update_constants()
-    3. self.create_new_session() or self.connect_as_extension().
-    4. self.get_primary_system()
-
-    After connection, many OpticStudio functionalities are controllable through ZOS.ZOSAPI()
-
-    Attributes
-    ----------
-        ZOSAPI (None | netModuleObject): The ZOSAPI interface or if loaded.
-        ZOSAPI_NetHelper (None | netModuleObject): The ZOSAPI_NetHelper interface if loaded.
+    and subsequently control OpticStudio. The connection is established in two ways, the preferred method as wel as a
+    legacy method for backwards compatability. See examples.
 
     Parameters
     ----------
-    preload: bool
-        A boolean indicating if nested namespaces should be preloaded.
-    zosapi_nethelper: str, optional
-        Optional filepath to the ZOSAPI_NetHelper dll, if None, the windows registry will be used to find
-        ZOSAPI_NetHelper dll. Defaults to None.
+    preload : bool
+        A boolean indicating if nested namespaces should be preloaded upon initiating ZOS. Defaults to False.
+    zosapi_nethelper : str | None
+        Optional filepath to the ZOSAPI_NetHelper dll that is required to connect to OpticStudio. If None, the
+        Windows registry will be used to find the ZOSAPI_NetHelper dll. Defaults to None.
+
+
+    Attributes
+    ----------
+    ZOSAPI : None | netModuleObject
+        The ZOSAPI interface once loaded, else None.
+    ZOSAPI_NetHelper : None | netModuleObject
+        The ZOSAPI_NetHelper interface once loaded, else None.
+
+    Examples
+    --------
+    >>> # Preferred methods:
+    >>>
+    >>> # Connecting as extension:
+    >>> import zospy as zp
+    >>> zos = zp.ZOS()
+    >>> oss = zos.connect_as_extension(return_primary_system=True)
+    >>>
+    >>> # Launching OpticStudio in standalone mode:
+    >>> import zospy as zp
+    >>> zos = zp.ZOS()
+    >>> oss = zos.create_new_application(return_primary_system=True)
+    >>>
+    >>>
+    >>>
+    >>> # Legacy methods:
+    >>>
+    >>> # Connecting as extension:
+    >>> import zospy as zp
+    >>> zos = zp.ZOS()
+    >>> zos.wakeup()
+    >>> zos.connect_as_extension()
+    >>> oss = zos.get_primary_system()
+    >>>
+    >>> # Launching OpticStudio in standalone mode:
+    >>> import zospy as zp
+    >>> zos = zp.ZOS()
+    >>> zos.wakeup()
+    >>> zos.create_new_application()
+    >>> oss = zos.get_primary_system()
     """
 
     _OpticStudioSystem = OpticStudioSystem
@@ -312,7 +335,19 @@ class ZOS:
         return instance
 
     def __init__(self, preload: bool = False, zosapi_nethelper: str = None):
-        """Initiation of the ZOS Instance."""
+        """Initiation of the ZOS Instance.
+
+        The ZOS instance can subsequently be used to connect to OpticStudio. See the examples in the class docstring for
+        more information
+
+        Parameters
+        ----------
+        preload : bool
+            A boolean indicating if nested namespaces should be preloaded upon initiating ZOS. Defaults to False.
+        zosapi_nethelper : str | None
+            Optional filepath to the ZOSAPI_NetHelper dll that is required to connect to OpticStudio. If None, the
+            Windows registry will be used to find the ZOSAPI_NetHelper dll. Defaults to None.
+        """
         logger.debug("Initializing ZOS instance")
 
         self.ZOSAPI: _ZOSAPI = None

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -300,7 +300,7 @@ class ZOS:
         if len(cls._instances) >= 1:
             # As the number of applications within runtime is limited to 1 by Zemax, it is logical to also limit the
             # number of ZOS instances
-            raise ValueError(
+            raise ConnectionRefusedError(
                 "Cannot have more than one active ZOS instance.\n\n"
                 "Since OpticStudio limits the number of connections to the ZOS-API to 1, only a single ZOS instance "
                 "is allowed. Re-use the existing instance, or delete the existing instance prior to initializing a "

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -456,6 +456,17 @@ class ZOS:
 
         if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
+            
+            if return_primary_system:
+                raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
+            
+            return False
+        
+        if return_primary_system:
+            return self.get_primary_system()
+            
+        return True
+            logger.critical("OpticStudio Licence is not valid for API, connection not established")
             raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
             return False
         else:

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -400,8 +400,8 @@ class ZOS:
         Returns
         -------
         bool | OpticStudioSystem
-            True if a valid connection is made, else False. If 'return_primary_system = True', the function
-            runs 'get_primary_system()' and directly returns OpticStudioSystem.
+            True if a valid connection is made, else False. If return_primary_system = True, the function
+            runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         self._assign_connection()
 
@@ -431,8 +431,8 @@ class ZOS:
         Returns
         -------
         bool | OpticStudioSystem
-            True if a valid connection is made, else False. If 'return_primary_system = True', the function
-            runs 'get_primary_system()' and directly returns OpticStudioSystem.
+            True if a valid connection is made, else False. If return_primary_system = True, the function
+            runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         self._assign_connection()
 
@@ -451,9 +451,7 @@ class ZOS:
     def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
 
-        The application will be assigned to self.Application.
-
-        This function is identical to 'create_new_application()'
+        Equal to ZOS.create_new_application().
 
         Parameters
         ----------
@@ -463,8 +461,8 @@ class ZOS:
         Returns
         -------
         bool | OpticStudioSystem
-            True if a valid connection is made, else False. If 'return_primary_system = True', the function
-            runs 'get_primary_system()' and directly returns OpticStudioSystem.
+            True if a valid connection is made, else False. If return_primary_system = True, the function
+            runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         return self.create_new_application(return_primary_system=return_primary_system)
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -438,7 +438,7 @@ class ZOS:
         instancenumber: int
             An integer to specify the number of the instance used.
         return_primary_system: bool
-            A boolean indicating if OpticStudioSystem should be returned directly.
+            A boolean indicating if the primary  OpticStudioSystem  should be returned.
 
         Returns
         -------

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -431,7 +431,7 @@ class ZOS:
     ) -> bool | OpticStudioSystem:
         """Connects to Zemax Opticstudio as extension.
 
-        The application will be assigned to self.Application.
+        The application will be assigned to ZOS.Application.
 
         Parameters
         ----------

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -417,7 +417,7 @@ class ZOS:
         else:
             if not return_primary_system:
                 return True
-            else
+            else:
                 return self.get_primary_system()
     
     def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
@@ -450,7 +450,7 @@ class ZOS:
         else:
             if not return_primary_system:
                 return True
-            else
+            else:
                 return self.get_primary_system()
  
     def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -337,8 +337,9 @@ class ZOS:
         -------
         None
         """
-        self._load_zos_dlls(preload=preload, zosapi_nethelper=zosapi_nethelper)
-        self._assign_connection()
+        if self.Connection is None:
+            self._load_zos_dlls(preload=preload, zosapi_nethelper=zosapi_nethelper)
+            self._assign_connection()
 
     def _load_zos_dlls(self, preload: bool = False, zosapi_nethelper: str = None):
         """Loads the ZOS-API DLLs and makes them available for usage through ZOS.ZOSAPI and ZOS.ZOSAPI_NetHelper.

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -393,11 +393,13 @@ class ZOS:
 
         self.Application = self.Connection.ConnectAsExtension(instancenumber)
 
-        if self.Application.IsValidLicenseForAPI:
-            return True
-        else:
+        if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
-            return False
+
+        assert self.Application.IsValidLicenseForAPI, "OpticStudio Licence is not valid for API, connection not established"
+        
+        return self.get_primary_system()
+        
 
     def create_new_application(self) -> bool:
         """Creates a standalone Zemax Opticstudio instance.
@@ -416,11 +418,13 @@ class ZOS:
 
         self.Application = self.Connection.CreateNewApplication()
 
-        if self.Application.IsValidLicenseForAPI:
-            return True
-        else:
+        if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
-            return False
+
+        assert self.Application.IsValidLicenseForAPI, "OpticStudio Licence is not valid for API, connection not established"
+        
+        return self.get_primary_system()
+        
 
     def create_new_system(self, system_mode: constants.SystemType | str = "Sequential") -> OpticStudioSystem:
         """Creates a new OpticStudioSystem. This works only if ZOSPy is connected to a standalone application.

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -443,7 +443,8 @@ class ZOS:
         Returns
         -------
         bool | OpticStudioSystem
-            True if a valid connection is made, else False. If return_primary_system = True, the function
+            `True` if a valid connection is made, else `False`. If `return_primary_system` is `True`, the function
+            returns the primary `OpticStudioSystem`.
             runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         self._assign_connection()

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -438,7 +438,7 @@ class ZOS:
         instancenumber: int
             An integer to specify the number of the instance used.
         return_primary_system: bool
-            A boolean indicating if the primary  OpticStudioSystem  should be returned.
+            A boolean indicating if the primary OpticStudioSystem should be returned.
 
         Returns
         -------
@@ -471,17 +471,18 @@ class ZOS:
     def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
 
-        The application will be assigned to self.Application.
+        The application will be assigned to ZOS.Application.
 
         Parameters
         ----------
         return_primary_system: bool
-            A boolean indicating if OpticStudioSystem should be returned directly.
+            A boolean indicating if the primary OpticStudioSystem should be returned.
 
         Returns
         -------
         bool | OpticStudioSystem
-            True if a valid connection is made, else False. If return_primary_system = True, the function
+            `True` if a valid connection is made, else `False`. If `return_primary_system` is `True`, the function
+            returns the primary `OpticStudioSystem`.
             runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         self._assign_connection()
@@ -512,12 +513,13 @@ class ZOS:
         Parameters
         ----------
         return_primary_system: bool
-            A boolean indicating if OpticStudioSystem should be returned directly.
+            A boolean indicating if the primary OpticStudioSystem should be returned.
 
         Returns
         -------
         bool | OpticStudioSystem
-            True if a valid connection is made, else False. If return_primary_system = True, the function
+            `True` if a valid connection is made, else `False`. If `return_primary_system` is `True`, the function
+            returns the primary `OpticStudioSystem`.
             runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         return self.create_new_application(return_primary_system=return_primary_system)

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -263,7 +263,7 @@ class ZOS:
     """A Communication instance for Zemax OpticStudio.
 
     This class can be used to establish a link between Python and Zemax OpticStudio through .NET,
-    and subsequently control OpticStudio. Only one instance of ZOS() can exist at any time.
+    and subsequently control OpticStudio. Only one instance of `ZOS` can exist at any time.
 
     The connection is established in two ways, the preferred method as wel as a legacy method for backwards
     compatability. See examples.
@@ -286,34 +286,36 @@ class ZOS:
     Raises
     ------
     ValueError
-        When it is attempted to initiate a second instance of ZOS(). Only one instance can exist at any time.
+        When it is attempted to initiate a second instance of  `ZOS`. Only one instance can exist at any time.
 
     Examples
     --------
-    >>> # Preferred methods:
-    >>>
-    >>> # Connecting as extension:
+    Preferred methods:
+
+    1. Connecting as extension:
+
     >>> import zospy as zp
     >>> zos = zp.ZOS()
     >>> oss = zos.connect_as_extension(return_primary_system=True)
-    >>>
-    >>> # Launching OpticStudio in standalone mode:
+
+    2. Launching OpticStudio in standalone mode:
+
     >>> import zospy as zp
     >>> zos = zp.ZOS()
     >>> oss = zos.create_new_application(return_primary_system=True)
-    >>>
-    >>>
-    >>>
-    >>> # Legacy methods:
-    >>>
-    >>> # Connecting as extension:
+
+    Legacy methods:
+
+    1. Connecting as extension:
+
     >>> import zospy as zp
     >>> zos = zp.ZOS()
     >>> zos.wakeup()
     >>> zos.connect_as_extension()
     >>> oss = zos.get_primary_system()
-    >>>
-    >>> # Launching OpticStudio in standalone mode:
+
+    2. Launching OpticStudio in standalone mode:
+
     >>> import zospy as zp
     >>> zos = zp.ZOS()
     >>> zos.wakeup()
@@ -341,10 +343,10 @@ class ZOS:
         return instance
 
     def __init__(self, preload: bool = False, zosapi_nethelper: str = None):
-        """Initiation of the ZOS Instance.
+        """Initiation of the ZOS instance.
 
         The ZOS instance can subsequently be used to connect to OpticStudio. See the examples in the class docstring for
-        more information
+        more information.
 
         Parameters
         ----------
@@ -376,10 +378,10 @@ class ZOS:
 
         Parameters
         ----------
-        preload: bool
+        preload : bool
             A boolean indicating if nested namespaces should be preloaded.
-        zosapi_nethelper: str, optional
-            Optional filepath to the ZOSAPI_NetHelper dll, if None, the windows registry will be used to find
+        zosapi_nethelper : str, optional
+            File path to the ZOSAPI_NetHelper dll, if None, the Windows registry will be used to find
             ZOSAPI_NetHelper dll. Defaults to None.
 
         Returns
@@ -411,8 +413,6 @@ class ZOS:
             An error occurred in locating one of the DLLs.
         ModuleNotFoundError:
             One of the nested namespaces cannot be found. This error can only occur with preload set to True.
-
-
         """
         logger.debug("Loading ZOS DLLs with preload set to {}".format(preload))
         self.ZOSAPI_NetHelper = load_zosapi_nethelper(filepath=zosapi_nethelper, preload=preload)
@@ -429,23 +429,22 @@ class ZOS:
     def connect_as_extension(
         self, instancenumber: int = 0, return_primary_system: bool = False
     ) -> bool | OpticStudioSystem:
-        """Connects to Zemax Opticstudio as extension.
+        """Connects to Zemax OpticStudio as extension.
 
         The application will be assigned to ZOS.Application.
 
         Parameters
         ----------
-        instancenumber: int
+        instancenumber : int, optional
             An integer to specify the number of the instance used.
-        return_primary_system: bool
-            A boolean indicating if the primary OpticStudioSystem should be returned.
+        return_primary_system: bool, optional
+            A boolean indicating if the primary OpticStudioSystem should be returned. Defaults to `False`.
 
         Returns
         -------
         bool | OpticStudioSystem
             `True` if a valid connection is made, else `False`. If `return_primary_system` is `True`, the function
             returns the primary `OpticStudioSystem`.
-            runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         self._assign_connection()
 
@@ -468,21 +467,20 @@ class ZOS:
         return True
 
     def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
-        """Creates a standalone Zemax Opticstudio instance.
+        """Creates a standalone Zemax OpticStudio instance.
 
         The application will be assigned to ZOS.Application.
 
         Parameters
         ----------
-        return_primary_system: bool
-            A boolean indicating if the primary OpticStudioSystem should be returned.
+        return_primary_system : bool, optional
+            A boolean indicating if the primary OpticStudioSystem should be returned. Defaults to `False`.
 
         Returns
         -------
         bool | OpticStudioSystem
             `True` if a valid connection is made, else `False`. If `return_primary_system` is `True`, the function
             returns the primary `OpticStudioSystem`.
-            runs ZOS.get_primary_system() and directly returns OpticStudioSystem.
         """
         self._assign_connection()
 
@@ -505,14 +503,14 @@ class ZOS:
         return True
 
     def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
-        """Creates a standalone Zemax Opticstudio instance.
+        """Creates a standalone Zemax OpticStudio instance.
 
-        Equal to ZOS.create_new_application().
+        Equal to `ZOS.create_new_application`.
 
         Parameters
         ----------
-        return_primary_system: bool
-            A boolean indicating if the primary OpticStudioSystem should be returned.
+        return_primary_system : bool, optional
+            A boolean indicating if the primary OpticStudioSystem should be returned. Defaults to `False`.
 
         Returns
         -------

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -323,7 +323,7 @@ class ZOS:
         if len(cls._instances) >= 1:
             # As the number of applications within runtime is limited to 1 by Zemax, it is logical to also limit the
             # number of ZOS instances
-            raise RuntimeError(
+            raise ValueError(
                 "Cannot have more than one active ZOS instance.\n\n"
                 "Since OpticStudio limits the number of connections to the ZOS-API to 1, only a single ZOS instance "
                 "is allowed. Re-use the existing instance, or delete the existing instance prior to initializing a "

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -385,15 +385,23 @@ class ZOS:
         else:
             logger.debug("ZOSAPI_Connection() already assigned self.Connection")
 
-    def connect_as_extension(self, instancenumber: int = 0) -> OpticStudioSystem:
+    def connect_as_extension(self, instancenumber: int = 0, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Connects to Zemax Opticstudio as extension.
 
         The application will be assigned to self.Application.
 
+        Parameters
+        ----------
+        instancenumber: int
+            An integer to specify the number of instance used.
+        return_primary_system: bool
+            A boolean indicating if OpticStudioSystem should be returned directly.
+
         Returns
         -------
-        OpticStudioSystem
-        
+        bool | OpticStudioSystem
+            True if a valid connection is made, else False. If 'return_primary_system = True', the function
+            runs 'get_primary_system()' and directly returns OpticStudioSystem.
         """
         self._assign_connection()
 
@@ -410,15 +418,21 @@ class ZOS:
         
         return self.get_primary_system()
     
-    def create_new_application(self) -> OpticStudioSystem:
+    def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
 
         The application will be assigned to self.Application.
 
+        Parameters
+        ----------
+        return_primary_system: bool
+            A boolean indicating if OpticStudioSystem should be returned directly.
+
         Returns
         -------
-        OpticStudioSystem
-
+        bool | OpticStudioSystem
+            True if a valid connection is made, else False. If 'return_primary_system = True', the function
+            runs 'get_primary_system()' and directly returns OpticStudioSystem.
         """
         self._assign_connection()
 
@@ -434,17 +448,25 @@ class ZOS:
         
         return self.get_primary_system()
  
-    def connect_as_standalone(self) -> OpticStudioSystem:
+    def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
 
         The application will be assigned to self.Application.
 
+        This function is identical to 'create_new_application()'
+
+        Parameters
+        ----------
+        return_primary_system: bool
+            A boolean indicating if OpticStudioSystem should be returned directly.
+
         Returns
         -------
-        OpticStudioSystem
-
+        bool | OpticStudioSystem
+            True if a valid connection is made, else False. If 'return_primary_system = True', the function
+            runs 'get_primary_system()' and directly returns OpticStudioSystem.
         """
-        return self.create_new_application()
+        return self.create_new_application(return_primary_system=return_primary_system)
 
     def create_new_system(self, system_mode: constants.SystemType | str = "Sequential") -> OpticStudioSystem:
         """Creates a new OpticStudioSystem. This works only if ZOSPy is connected to a standalone application.

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -263,8 +263,10 @@ class ZOS:
     """A Communication instance for Zemax OpticStudio.
 
     This class can be used to establish a link between Python and Zemax OpticStudio through .NET,
-    and subsequently control OpticStudio. The connection is established in two ways, the preferred method as wel as a
-    legacy method for backwards compatability. See examples.
+    and subsequently control OpticStudio. Only one instance of ZOS() can exist at any time.
+
+    The connection is established in two ways, the preferred method as wel as a legacy method for backwards
+    compatability. See examples.
 
     Parameters
     ----------
@@ -282,6 +284,10 @@ class ZOS:
     ZOSAPI_NetHelper : None | netModuleObject
         The ZOSAPI_NetHelper interface once loaded, else None.
 
+    Raises
+    ------
+    ValueError
+        When it is attempted to initiate a second instance of ZOS(). Only one instance can exist at any time.
     Examples
     --------
     >>> # Preferred methods:

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -323,7 +323,7 @@ class ZOS:
         if len(cls._instances) >= 1:
             # As the number of applications within runtime is limited to 1 by Zemax, it is logical to also limit the
             # number of ZOS instances
-            raise ConnectionRefusedError(
+            raise RuntimeError(
                 "Cannot have more than one active ZOS instance.\n\n"
                 "Since OpticStudio limits the number of connections to the ZOS-API to 1, only a single ZOS instance "
                 "is allowed. Re-use the existing instance, or delete the existing instance prior to initializing a "

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -376,15 +376,15 @@ class ZOS:
         else:
             logger.debug("ZOSAPI_Connection() already assigned self.Connection")
 
-    def connect_as_extension(self, instancenumber: int = 0) -> bool:
-        """Creates a standalone Zemax Opticstudio instance.
+    def connect_as_extension(self, instancenumber: int = 0) -> OpticStudioSystem:
+        """Connects to Zemax Opticstudio as extension.
 
         The application will be assigned to self.Application.
 
         Returns
         -------
-        bool
-            True if a valid connection is made, else False
+        OpticStudioSystem
+        
         """
         self._assign_connection()
 
@@ -399,17 +399,16 @@ class ZOS:
         assert self.Application.IsValidLicenseForAPI, "OpticStudio Licence is not valid for API, connection not established"
         
         return self.get_primary_system()
-        
-
-    def create_new_application(self) -> bool:
+    
+    def create_new_application(self) -> OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
 
         The application will be assigned to self.Application.
 
         Returns
         -------
-        bool
-            True if a valid connection is made, else False
+        OpticStudioSystem
+
         """
         self._assign_connection()
 
@@ -424,7 +423,18 @@ class ZOS:
         assert self.Application.IsValidLicenseForAPI, "OpticStudio Licence is not valid for API, connection not established"
         
         return self.get_primary_system()
-        
+ 
+    def connect_as_standalone(self) -> OpticStudioSystem:
+        """Creates a standalone Zemax Opticstudio instance.
+
+        The application will be assigned to self.Application.
+
+        Returns
+        -------
+        OpticStudioSystem
+
+        """
+        return self.create_new_application()
 
     def create_new_system(self, system_mode: constants.SystemType | str = "Sequential") -> OpticStudioSystem:
         """Creates a new OpticStudioSystem. This works only if ZOSPy is connected to a standalone application.

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -436,7 +436,7 @@ class ZOS:
         Parameters
         ----------
         instancenumber: int
-            An integer to specify the number of instance used.
+            An integer to specify the number of the instance used.
         return_primary_system: bool
             A boolean indicating if OpticStudioSystem should be returned directly.
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -404,6 +404,8 @@ class ZOS:
 
         if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
+            raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
+            logger.critical("OpticStudio Licence is not valid for API, connection not established")
 
         assert self.Application.IsValidLicenseForAPI, "OpticStudio Licence is not valid for API, connection not established"
         

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -420,7 +420,9 @@ class ZOS:
         else:
             logger.debug("ZOSAPI_Connection() already assigned self.Connection")
 
-    def connect_as_extension(self, instancenumber: int = 0, return_primary_system: bool = False) -> bool | OpticStudioSystem:
+    def connect_as_extension(
+        self, instancenumber: int = 0, return_primary_system: bool = False
+    ) -> bool | OpticStudioSystem:
         """Connects to Zemax Opticstudio as extension.
 
         The application will be assigned to self.Application.
@@ -454,7 +456,7 @@ class ZOS:
                 return True
             else:
                 return self.get_primary_system()
-    
+
     def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
 
@@ -487,7 +489,7 @@ class ZOS:
                 return True
             else:
                 return self.get_primary_system()
- 
+
     def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -276,7 +276,6 @@ class ZOS:
         Optional filepath to the ZOSAPI_NetHelper dll that is required to connect to OpticStudio. If None, the
         Windows registry will be used to find the ZOSAPI_NetHelper dll. Defaults to None.
 
-
     Attributes
     ----------
     ZOSAPI : None | netModuleObject
@@ -288,6 +287,7 @@ class ZOS:
     ------
     ValueError
         When it is attempted to initiate a second instance of ZOS(). Only one instance can exist at any time.
+
     Examples
     --------
     >>> # Preferred methods:
@@ -456,17 +456,16 @@ class ZOS:
 
         if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
-            
+
             if return_primary_system:
                 raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
-            
+
             return False
-        
+
         if return_primary_system:
             return self.get_primary_system()
-            
-        return True
 
+        return True
 
     def create_new_application(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:
         """Creates a standalone Zemax Opticstudio instance.
@@ -494,15 +493,15 @@ class ZOS:
 
         if not self.Application.IsValidLicenseForAPI:
             logger.critical("OpticStudio Licence is not valid for API, connection not established")
-            
+
             if return_primary_system:
                 raise ConnectionRefusedError("OpticStudio Licence is not valid for API, connection not established")
-            
+
             return False
-        
+
         if return_primary_system:
             return self.get_primary_system()
-            
+
         return True
 
     def connect_as_standalone(self, return_primary_system: bool = False) -> bool | OpticStudioSystem:

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -282,13 +282,21 @@ class ZOS:
     ----------
         ZOSAPI (None | netModuleObject): The ZOSAPI interface or if loaded.
         ZOSAPI_NetHelper (None | netModuleObject): The ZOSAPI_NetHelper interface if loaded.
+
+    Parameters
+    ----------
+    preload: bool
+        A boolean indicating if nested namespaces should be preloaded.
+    zosapi_nethelper: str, optional
+        Optional filepath to the ZOSAPI_NetHelper dll, if None, the windows registry will be used to find
+        ZOSAPI_NetHelper dll. Defaults to None.
     """
 
     _OpticStudioSystem = OpticStudioSystem
 
     _instances = set()
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, preload: bool = False, zosapi_nethelper: str = None, *args, **kwargs):
         if len(cls._instances) >= 1:
             # As the number of applications within runtime is limited to 1 by Zemax, it is logical to also limit the
             # number of ZOS instances
@@ -303,7 +311,7 @@ class ZOS:
 
         return instance
 
-    def __init__(self):
+    def __init__(self, preload: bool = False, zosapi_nethelper: str = None):
         """Initiation of the ZOS Instance."""
         logger.debug("Initializing ZOS instance")
 
@@ -318,7 +326,7 @@ class ZOS:
 
         logger.info("ZOS instance initialized")
 
-        self.wakeup()
+        self.wakeup(preload=preload, zosapi_nethelper=zosapi_nethelper)
 
     def wakeup(self, preload: bool = False, zosapi_nethelper: str = None):
         """Wakes the zosapi instance.


### PR DESCRIPTION
I implemented changes discussed in https://github.com/MREYE-LUMC/ZOSPy/discussions/20. Indeed, I can now initialize ZOSpy with just two lines:

```python
import zospy as zp

zos = zp.ZOS()
oss = zos.connect_as_standalone()
``` 

Note that I introduced a new function `zos.connect_as_standalone()` which is identical to `zos.create_new_application()`, because I find that here the word 'standalone' is important to be more consistent with the ZOS API.

At the moment, I don't see anything breaking and it should be backward compatible, as long as ZOSpy is initialized exactly as described in the readme (without another assert in the main script to check connection). I have tested it with my own scripts but I have not run a unit test, since I am currently trying to wrap my head around that :).

Let me know what you think.

Edit: Corrected code snippet.