### PR TITLE
Fix unsupported locale exception on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ ZOS-API can also be added in patch releases.
 
 ### Fixed
 
+- Unsupported locale setting on import (#66)
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ ZOS-API can also be added in patch releases.
 
 ### Fixed
 
-- Unsupported locale setting on import (#66)
+- Unsupported locale setting on import (#66, #69)
 
 ### Changed
 

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -175,10 +175,10 @@ class TestTxtFileEncoding:
     def test_get_txtfile_encoding_returns_correct_result(
         self, oss_with_modifiable_config, txtfile_encoding, expected_encoding, monkeypatch: pytest.MonkeyPatch
     ):
-        def getpreferredencoding(**kwargs):
+        def getencoding(**kwargs):
             return "LocalePreferredEncoding"
 
-        monkeypatch.setattr(locale, "getpreferredencoding", getpreferredencoding)
+        monkeypatch.setattr(locale, "getencoding", getencoding)
 
         oss_with_modifiable_config._ZOS.Application.Preferences.General.TXTFileEncoding = getattr(
             constants.Preferences.EncodingType, txtfile_encoding

--- a/tests/utils/test_pyutils.py
+++ b/tests/utils/test_pyutils.py
@@ -94,16 +94,15 @@ class TestNumberToStringConversion:
         # get new locale
         loc = locale.setlocale(locale.LC_NUMERIC)
         locale.setlocale(locale.LC_NUMERIC, new_locale)
-        _config.THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
-        _config.DECIMAL_POINT = locale.localeconv()["decimal_point"]
+
+        monkeypatch.setattr(_config, "THOUSANDS_SEPARATOR", locale.localeconv()["thousands_sep"])
+        monkeypatch.setattr(_config, "DECIMAL_POINT", locale.localeconv()["decimal_point"])
 
         # convert
         result = xtoa(number)
 
         # restore saved locale
         locale.setlocale(locale.LC_NUMERIC, loc)
-        _config.THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
-        _config.DECIMAL_POINT = locale.localeconv()["decimal_point"]
 
         assert result == expected_output
 

--- a/tests/utils/test_pyutils.py
+++ b/tests/utils/test_pyutils.py
@@ -85,12 +85,14 @@ class TestNumberToStringConversion:
             ("zh_CN", 1234.5, "1,234.5"),
         ],
     )
-    def test_xtoa_converts_number_correctly_for_different_locale_categories(self, new_locale, number, expected_output):
+    def test_xtoa_converts_number_correctly_for_different_locale_categories(
+        self, new_locale, number, expected_output, monkeypatch
+    ):
         if new_locale not in locale.windows_locale.values():
             pytest.skip(f"Locale '{new_locale}' not available.")
 
         # get new locale
-        loc = locale.getlocale()
+        loc = locale.setlocale(locale.LC_NUMERIC)
         locale.setlocale(locale.LC_NUMERIC, new_locale)
         _config.THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
         _config.DECIMAL_POINT = locale.localeconv()["decimal_point"]
@@ -183,24 +185,23 @@ class TestStringToNumberConversion:
         ],
     )
     def test_xtoa_converts_string_correctly_for_different_locale_categories(
-        self, locale_cat, string, dtype, expected_output
+        self, locale_cat, string, dtype, expected_output, monkeypatch
     ):
         if locale_cat not in locale.windows_locale.values():
             pytest.skip(f"Locale '{locale_cat}' not available.")
 
         # get new locale
-        loc = locale.getlocale()
+        loc = locale.setlocale(locale.LC_NUMERIC)
         locale.setlocale(locale.LC_NUMERIC, locale_cat)
-        _config.THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
-        _config.DECIMAL_POINT = locale.localeconv()["decimal_point"]
+
+        monkeypatch.setattr(_config, "THOUSANDS_SEPARATOR", locale.localeconv()["thousands_sep"])
+        monkeypatch.setattr(_config, "DECIMAL_POINT", locale.localeconv()["decimal_point"])
 
         # convert
         result = atox(string, dtype=dtype)
 
         # restore saved locale
         locale.setlocale(locale.LC_NUMERIC, loc)
-        _config.THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
-        _config.DECIMAL_POINT = locale.localeconv()["decimal_point"]
 
         assert result == expected_output
 

--- a/zospy/api/config.py
+++ b/zospy/api/config.py
@@ -1,4 +1,7 @@
 import locale
+import logging
+
+logger = logging.getLogger(__name__)
 
 DECIMAL_POINT = locale.localeconv()["decimal_point"]
 THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
@@ -23,8 +26,14 @@ def set_decimal_point_and_thousands_separator() -> None:
     global DECIMAL_POINT
     global THOUSANDS_SEPARATOR
 
-    loc = locale.getlocale()  # get and save current locale
-    locale.setlocale(locale.LC_ALL, "")
-    DECIMAL_POINT = locale.localeconv()["decimal_point"]
-    THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
-    locale.setlocale(locale.LC_ALL, loc)  # restore saved locale
+    old_locale = locale.setlocale(locale.LC_NUMERIC)  # get and save current numeric locale
+
+    try:
+        locale.setlocale(locale.LC_NUMERIC, "")
+
+        DECIMAL_POINT = locale.localeconv()["decimal_point"]
+        THOUSANDS_SEPARATOR = locale.localeconv()["thousands_sep"]
+    except locale.Error:
+        logger.error("Failed to determine decimal point and thousands separator", exc_info=True)
+    finally:
+        locale.setlocale(locale.LC_NUMERIC, old_locale)  # restore saved locale

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -769,7 +769,7 @@ class ZOS:
         if str(self.Application.Preferences.General.TXTFileEncoding) == "Unicode":
             return "UTF-16-le"
         elif str(self.Application.Preferences.General.TXTFileEncoding) == "ANSI":
-            return locale.getpreferredencoding(do_setlocale=False)
+            return locale.getencoding()
         else:
             raise NotImplementedError(
                 f"ZOSPy cannot handle encoding {str(self.Application.Preferences.General.TXTFileEncoding)}"


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

Use `locale.setlocale(locale.LC_NUMERIC)` instead of `locale.getlocale()` to determine the locale in `zospy.api.config`.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.9-3.12
- OpticStudio version: 2024 R1

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

Closes #66 

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I added new tests for any features contributed, or updated existing tests.
- [x] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
