### PR TITLE
Fix date being parsed as floats in `zospy.analyses.wavefront.zernike_standard_coefficients`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ ZOS-API can also be added in patch releases.
 ### Fixed
 
 - Unsupported locale setting on import (#66, #69)
-- Zernike Standard Coefficients analysis parses dates as floats under German locale (#67)
+- Zernike Standard Coefficients analysis parses dates as floats under German locale (#70)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ZOS-API can also be added in patch releases.
 ### Fixed
 
 - Unsupported locale setting on import (#66, #69)
+- Zernike Standard Coefficients analysis parses dates as floats under German locale (#67)
 
 ### Changed
 

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -1,5 +1,6 @@
 import locale
 from pathlib import Path
+from sys import version_info
 from types import SimpleNamespace
 
 import pytest
@@ -175,10 +176,13 @@ class TestTxtFileEncoding:
     def test_get_txtfile_encoding_returns_correct_result(
         self, oss_with_modifiable_config, txtfile_encoding, expected_encoding, monkeypatch: pytest.MonkeyPatch
     ):
-        def getencoding(**kwargs):
+        def getencoding(*args, **kwargs):
             return "LocalePreferredEncoding"
 
-        monkeypatch.setattr(locale, "getencoding", getencoding)
+        if version_info < (3, 11):
+            monkeypatch.setattr(locale, "getpreferredencoding", getencoding)
+        else:
+            monkeypatch.setattr(locale, "getencoding", getencoding)
 
         oss_with_modifiable_config._ZOS.Application.Preferences.General.TXTFileEncoding = getattr(
             constants.Preferences.EncodingType, txtfile_encoding

--- a/zospy/analyses/wavefront.py
+++ b/zospy/analyses/wavefront.py
@@ -52,7 +52,9 @@ def _structure_zernike_standard_coefficients_result(line_list: list[str]) -> tup
                 unit = ""
                 general_data.loc[ind] = [val, unit]
             elif len(dat) == 1:
-                if valuepat_start.search(dat[0].replace(",", ".")):  # value is number
+                if ind == "Date":
+                    val = dat[0]
+                elif valuepat_start.search(dat[0].replace(",", ".")):  # value is number
                     val = float(dat[0].replace(",", "."))
                 else:
                     val = dat[0]

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -5,8 +5,8 @@ import logging
 import warnings
 import weakref
 from os import PathLike
-from typing import Literal
 from sys import version_info
+from typing import Literal
 
 from semver.version import Version
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -6,6 +6,7 @@ import warnings
 import weakref
 from os import PathLike
 from typing import Literal
+from sys import version_info
 
 from semver.version import Version
 
@@ -769,6 +770,11 @@ class ZOS:
         if str(self.Application.Preferences.General.TXTFileEncoding) == "Unicode":
             return "UTF-16-le"
         elif str(self.Application.Preferences.General.TXTFileEncoding) == "ANSI":
+            if version_info < (3, 11):
+                return locale.getpreferredencoding(False)
+
+            # Python 3.11 introduced locale.getencoding, which returns the system preferred encoding also if Python's
+            # UTF-8 mode is enabled
             return locale.getencoding()
         else:
             raise NotImplementedError(


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

German date notation uses dots to separate the date (e.g. 11.03.2024 for March 11th, 2024).
The current Zernike Standard Coefficients parser detects these as floats. 
This is solved by parsing the date separately, so it is not processed as a float.
This is a quick fix and only intended to last until we release the new analysis parsers.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.9-3.12
- OpticStudio version: 24 R1

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

Closes #67 

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I added new tests for any features contributed, or updated existing tests.
- [x] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
