### PR TITLE
Add analysis and tests for the surface category

### DIFF
--- a/tests/analyses/new/test_surface.py
+++ b/tests/analyses/new/test_surface.py
@@ -1,0 +1,11 @@
+from zospy.analyses.new.surface import Curvature
+
+
+class TestCurvature:
+    def test_can_run(self, simple_system):
+        result = Curvature().run(simple_system)
+        assert result.data is not None
+
+    def test_to_json(self, simple_system):
+        result = Curvature().run(simple_system)
+        assert result.from_json(result.to_json()).to_json() == result.to_json()

--- a/zospy/analyses/new/__init__.py
+++ b/zospy/analyses/new/__init__.py
@@ -20,12 +20,13 @@ Open an analysis for which a wrapper function is not yet available:
 ... )
 """
 
-from zospy.analyses.new import mtf, polarization, raysandspots, reports, wavefront
+from zospy.analyses.new import mtf, polarization, raysandspots, reports, surface, wavefront
 
 __all__ = (
     "mtf",
     "polarization",
     "raysandspots",
     "reports",
+    "surface",
     "wavefront",
 )

--- a/zospy/analyses/new/mtf/fft_through_focus_mtf.py
+++ b/zospy/analyses/new/mtf/fft_through_focus_mtf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Union
 
 from pandas import DataFrame
 from pydantic import Field
@@ -55,7 +55,7 @@ class FFTThroughFocusMTFSettings:
     use_dashes: bool = Field(default=False, description="Use dashes")
 
 
-class FFTThroughFocusMTF(BaseAnalysisWrapper[DataFrame | None, FFTThroughFocusMTFSettings]):
+class FFTThroughFocusMTF(BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughFocusMTFSettings]):
     """FFT Through Focus MTF analysis."""
 
     TYPE = "FftThroughFocusMtf"

--- a/zospy/analyses/new/surface/__init__.py
+++ b/zospy/analyses/new/surface/__init__.py
@@ -1,0 +1,5 @@
+"""OpticStudio analyses from the Surface category."""
+
+from zospy.analyses.new.surface.curvature import Curvature
+
+__all__ = ("Curvature",)

--- a/zospy/analyses/new/surface/curvature.py
+++ b/zospy/analyses/new/surface/curvature.py
@@ -1,0 +1,160 @@
+"""Surface Curvature analysis."""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated
+
+from pydantic import Field
+
+from zospy.analyses.new.base import BaseAnalysisWrapper
+from zospy.analyses.new.decorators import analysis_result, analysis_settings
+from zospy.analyses.new.parsers.types import ValidatedDataFrame  # noqa: TCH001
+from zospy.api import config, constants
+from zospy.utils.zputils import standardize_sampling, unpack_datagrid
+
+__all__ = ("Curvature", "CurvatureSettings")
+
+
+@analysis_result
+class CurvatureResult:
+    width: float
+    decenter_x: float
+    decenter_y: float
+    decenter_unit: str
+    data: ValidatedDataFrame
+
+
+@analysis_settings
+class CurvatureSettings:
+    """Settings for the Curvature analysis.
+
+    Attributes
+    ----------
+    sampling : str | int
+        The size of the used grid, either string (e.g. '65x65') or int. The integer will be treated as if obtained from
+        zospy.constants.Analysis.SampleSizes_Pow2Plus1_X. Defaults to '65x65'.
+    data : str
+        The used data type. Should be one of ['TangentialCurvature', 'SagittalCurvature', 'X_Curvature', 'Y_Curvature']
+        or int. The integer will be treated as if obtained from zospy.constants.Analysis.SurfaceCurvatureData. Defaults
+        to 'TangentialCurvature'.
+    remove : str
+        Defines whether a reference volume is removed or not. Should be one of ['None', 'BaseROC', 'BestFitSphere'] or
+        int. The integer will be treated as if obtained from zospy.constants.Analysis.RemoveOptions. Defaults
+        to 'None'.
+    surface : int
+        The surface that is te be analyzed. defaults to 1.
+    show_as : str
+        Defines how the data is displayed in OpticStudio. Should be one of ['Surface', 'Contour', 'GreyScale',
+        'InverseGreyScale', 'FalseColor', 'InverseFalseColor'] or int. The integer will be treated as if obtained from
+        `zospy.constants.Analysis.ShowAs`. Defaults to 'Contour'.
+    off_axis_coordinates : bool
+        Defines whether apertures defined in the Surface Properties of the surface are considered or not. Defaults to
+        `False`.
+    contour_format : str
+        The contour format. Only usable when showas == 'Contour'. Defaults to ''.
+    bfs_criterion : str | int
+        The criterion for BFS removal. Only usable when remove == 'BestFitSphere'. Should be one of ['MinimumVolume',
+        'MinimumRMS', 'MinimumRMSWithOffset'] or int. The integer will be treated as if obtained from
+        constants.Analysis.BestFitSphereOptions. Defaults to 'MinimumVolume'.
+    bfs_reverse_direction : bool
+        Defines if the sign of the BFS radius should be reversed or not. Only usable when remove == 'BestFitSphere'
+        and bfs_criterion == 'MinimumVolume'. Defaults to `False`.
+    """
+
+    sampling: str | Annotated[int, Field(ge=0)] = Field(default="65x65", description="Sampling grid size")
+    data: str = Field(default="TangentialCurvature", description="Data type")
+    remove: str = Field(default="None_", description="Reference volume removal")
+    surface: int = Field(default=1, description="Surface number")
+    show_as: str = Field(default="Contour", description="Data display in OpticStudio")
+    off_axis_coordinates: bool = Field(default=False, description="Consider apertures defined in surface properties")
+    contour_format: str = Field(default="", description="Contour format")
+    bfs_criterion: str = Field(default="MinimumVolume", description="BFS removal criterion")
+    bfs_reverse_direction: bool = Field(default=False, description="Reverse BFS radius sign")
+
+
+class Curvature(BaseAnalysisWrapper[CurvatureResult, CurvatureSettings]):
+    """Surface Curvature analysis."""
+
+    TYPE = "SurfaceCurvature"
+
+    def __init__(
+        self,
+        *,
+        sampling: str | int = "65x65",
+        data: str | constants.Analysis.SurfaceCurvatureData = "TangentialCurvature",
+        remove: str | constants.Analysis.RemoveOptions = "None_",
+        surface: int = 1,
+        show_as: str | constants.Analysis.ShowAs = "Contour",
+        off_axis_coordinates: bool = False,
+        contour_format: str = "",
+        bfs_criterion: str | constants.Analysis.BestFitSphereOptions = "MinimumVolume",
+        bfs_reverse_direction: bool = False,
+        settings: CurvatureSettings | None = None,
+    ):
+        """Create a new Curvature analysis.
+
+        See Also
+        --------
+        CurvatureSettings : Settings for the Curvature analysis.
+        """
+        super().__init__(settings or CurvatureSettings(), locals())
+
+    def run_analysis(self) -> list[CurvatureResult] | None:
+        """Run the Curvature analysis."""
+        self.analysis.Settings.Sampling = getattr(
+            constants.Analysis.SampleSizes_Pow2Plus1_X, standardize_sampling(self.settings.sampling)
+        )
+        self.analysis.Settings.Data = constants.process_constant(
+            constants.Analysis.SurfaceCurvatureData, self.settings.data
+        )
+        self.analysis.Settings.RemoveOption = constants.process_constant(
+            constants.Analysis.RemoveOptions, self.settings.remove
+        )
+        self.analysis.surface = self.settings.surface
+        self.analysis.Settings.ShowAs = constants.process_constant(constants.Analysis.ShowAs, self.settings.show_as)
+        self.analysis.Settings.OffAxisCoordinates = self.settings.off_axis_coordinates
+
+        if self.analysis.Settings.ShowAs == constants.Analysis.ShowAs.Contour:
+            self.analysis.Settings.ContourFormat = self.settings.contour_format
+
+        if self.analysis.Settings.RemoveOption == constants.Analysis.RemoveOptions.BestFitSphere:
+            self.analysis.Settings.BestFitSphereOption = constants.process_constant(
+                constants.Analysis.BestFitSphereOptions, self.settings.bfs_criterion
+            )
+            if self.analysis.Settings.BestFitSphereOption == constants.Analysis.BestFitSphereOptions.MinimumVolume:
+                self.analysis.Settings.BFSReverseDirection = self.settings.bfs_reverse_direction
+
+        # Run analysis
+        self.analysis.ApplyAndWaitForCompletion()
+
+        return self.get_data_grid()
+
+    def get_data_grid(self) -> CurvatureResult | None:
+        """Get the data grids from the Curvature analysis."""
+        curvature_description_regex = re.compile(
+            rf"Width = (?P<width>\d+(\{config.DECIMAL_POINT}\d+)?), "
+            rf"Decenter x = (?P<decenter_x>\d+(\{config.DECIMAL_POINT}\d+)?), "
+            rf"y = (?P<decenter_y>\d+(\{config.DECIMAL_POINT}\d+)?) (?P<decenter_unit>\w+)\.",
+            re.IGNORECASE,
+        )
+
+        if self.analysis.Results.NumberOfDataGrids == 0:
+            return None
+
+        if self.analysis.Results.NumberOfDataGrids > 1:
+            raise NotImplementedError("Curvature results with multiple data grids are not supported.")
+
+        datagrid = self.analysis.Results.GetDataGrid(0)
+        match = curvature_description_regex.match(datagrid.Description)
+
+        if match is None:
+            raise ValueError(f"Could not parse description: {datagrid.Description}")
+
+        return CurvatureResult(
+            width=match.group("width"),
+            decenter_x=match.group("decenter_x"),
+            decenter_y=match.group("decenter_y"),
+            decenter_unit=match.group("decenter_unit"),
+            data=unpack_datagrid(datagrid),
+        )


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

Add a new-style analysis for the surface curvature analysis.
Note that this implementation assumes that the analysis result contains only a single data grid. I don't see how the results of this analysis can contain multiple, but I decided to raise a NotImplementedError if this appears to be possible.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.9-3.12
- OpticStudio version: 24R1

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [x] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
