### PR TITLE
Implemented a fix for instances where datagrid.Description did not su…

### DIFF
--- a/zospy/analyses/new/surface/curvature.py
+++ b/zospy/analyses/new/surface/curvature.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Annotated
 
@@ -147,6 +148,13 @@ class Curvature(BaseAnalysisWrapper[CurvatureResult, CurvatureSettings]):
 
         datagrid = self.analysis.Results.GetDataGrid(0)
         match = curvature_description_regex.match(datagrid.Description)
+
+        if match is None:  # fall back to using exported text files
+            logging.warning("Could not obtain description parameters from datagrid.Description, trying to use exported textfile")
+
+            self._needs_text_output_file = True
+            self._text_output_file, self._remove_text_output_file = self._create_tempfile(None, ".txt")
+            match = curvature_description_regex.search(self.get_text_output())
 
         if match is None:
             raise ValueError(f"Could not parse description: {datagrid.Description}")


### PR DESCRIPTION
…pply the full description

<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
  The new curvature analysis uses `datagrid.Description` to obtain information on the centration of the grid. `datagrid.Description` however returns different information in older OpticStudio versions, causing an error in the curvature analysis. This PR fixes that issue with aa fallback to `GetTextFile` if `datagrid.Description` provides insufficient information.

## Type of change


- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.11
- OpticStudio version: 20.3.2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->
#94 

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
