### PR TITLE
Fixed set_surface for object surface

### DIFF
--- a/zospy/analyses/base.py
+++ b/zospy/analyses/base.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from enum import Enum
 from importlib import import_module
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -564,12 +564,12 @@ class Analysis:
 
         return "All" if wavelength == 0 else wavelength
 
-    def set_surface(self, value: int | str):
+    def set_surface(self, value: int | Literal["Image", "Objective", "Object"]):
         """Sets the surface value for the analysis.
 
         Parameters
         ----------
-        value : int or str
+        value : int or Literal["Image", "Objective", "Object"]
             The value to which the surface should be set. Either int or str. Accepts only 'Image' or 'Objective' as
             string.
 
@@ -581,11 +581,11 @@ class Analysis:
         ------
         ValueError
             When 'value' is not integer or string. When it is a string, it also raises an error when the string does not
-            equal 'Image' or 'Objective'.
+            equal 'Image', 'Objective' or 'Object'.
         """
         if value == "Image":
             self.Settings.Surface.UseImageSurface()
-        elif value == "Objective":
+        elif value in ("Object", "Objective"):
             self.Settings.Surface.UseObjectiveSurface()
         elif isinstance(value, int):
             self.Settings.Surface.SetSurfaceNumber(value)


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

The `surface` parameter of `set_surface` currrely allows "Image", "Objective" or an integer. Most analyses however ask the user for "Object" rather than "Objective" for the `surface` parameter, causing a error when the surface is supplies. This PR fixes that by also allowing "Object".

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.11
- OpticStudio version: 20.3.2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
