### PR TITLE
Only allow to set existing attributes on OpticStudio analyses

### DIFF
--- a/tests/analyses/new/test_base.py
+++ b/tests/analyses/new/test_base.py
@@ -16,10 +16,42 @@ from zospy.analyses.new.base import (
     AnalysisMetadata,
     AnalysisResult,
     BaseAnalysisWrapper,
+    _validated_setter,
 )
 from zospy.analyses.new.parsers.types import ValidatedDataFrame
 from zospy.analyses.new.reports.surface_data import SurfaceDataSettings
 from zospy.analyses.new.systemviewers.base import SystemViewerWrapper
+
+
+class TestValidatedSetter:
+    class MockSettings:
+        int_setting: int = 1
+        string_setting: str = "a"
+
+    def test_get_existing(self):
+        settings = _validated_setter(self.MockSettings())
+
+        assert settings.int_setting == self.MockSettings.int_setting
+
+    def test_get_non_existing(self):
+        settings = _validated_setter(self.MockSettings())
+
+        with pytest.raises(AttributeError):
+            assert settings.non_existing
+
+    def test_set_existing(self):
+        settings = _validated_setter(self.MockSettings())
+
+        settings.int_setting = 2
+
+        assert settings.int_setting == 2
+
+    def test_set_non_existing(self):
+        settings = _validated_setter(self.MockSettings())
+
+        with pytest.raises(AttributeError, match="'MockSettings' object has no attribute 'non_existing'"):
+            settings.non_existing = 2
+
 
 analysis_wrapper_classes = BaseAnalysisWrapper.__subclasses__()
 analysis_wrapper_classes.remove(SystemViewerWrapper)

--- a/tests/analyses/new/test_mtf.py
+++ b/tests/analyses/new/test_mtf.py
@@ -1,0 +1,21 @@
+from zospy.analyses.new.mtf import FFTThroughFocusMTF, HuygensMTF
+
+
+class TestFFTThroughFocusMTF:
+    def test_can_run(self, simple_system):
+        result = FFTThroughFocusMTF().run(simple_system)
+        assert result.data is not None
+
+    def test_to_json(self, simple_system):
+        result = FFTThroughFocusMTF().run(simple_system)
+        assert result.from_json(result.to_json()).to_json() == result.to_json()
+
+
+class TestHuygensMTF:
+    def test_can_run(self, simple_system):
+        result = HuygensMTF().run(simple_system)
+        assert result.data is not None
+
+    def test_to_json(self, simple_system):
+        result = HuygensMTF().run(simple_system)
+        assert result.from_json(result.to_json()).to_json() == result.to_json()

--- a/zospy/analyses/new/__init__.py
+++ b/zospy/analyses/new/__init__.py
@@ -21,6 +21,7 @@ Open an analysis for which a wrapper function is not yet available:
 """
 
 from zospy.analyses.new import mtf, polarization, raysandspots, reports, surface, systemviewers, wavefront
+from zospy.analyses.new.base import new_analysis
 
 __all__ = (
     "mtf",
@@ -30,4 +31,5 @@ __all__ = (
     "surface",
     "systemviewers",
     "wavefront",
+    "new_analysis",
 )

--- a/zospy/analyses/new/base.py
+++ b/zospy/analyses/new/base.py
@@ -245,8 +245,44 @@ class OnComplete(str, Enum):
     """Keep the analysis open and active."""
 
 
+class _ValidatedSetter:
+    """Wrapper class that only allows to set existing properties."""
+
+    __slots__ = ("_obj",)
+
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __getattr__(self, name):
+        return getattr(self._obj, name)
+
+    def __setattr__(self, name, value):
+        if name in self.__slots__:
+            super().__setattr__(name, value)
+        elif hasattr(self._obj, name):
+            setattr(self._obj, name, value)
+        else:
+            raise AttributeError(f"'{type(self._obj).__name__}' object has no attribute '{name}'")
+
+
+_ValidatedSetterType = TypeVar("_ValidatedSetterType")
+
+
+def _validated_setter(obj: _ValidatedSetterType) -> _ValidatedSetterType:
+    """Wrap an object to only allow setting existing properties.
+
+    Helper function that retains the original object's type information.
+
+    Parameters
+    ----------
+    obj : Any
+        The object to wrap.
+    """
+    return _ValidatedSetter(obj)
+
+
 class Analysis:
-    """Zemax OpticStudio analysis.
+    """OpticStudio analysis.
 
     This class wraps ZOSAPI analysis objects to provide direct access to its settings and results.
     All properties and methods of the ZOSAPI analysis object are available through this class.
@@ -260,12 +296,12 @@ class Analysis:
         analysis : ZOSAPI.Analysis.IA_
             analysis object
         """
-        self._analysis = analysis
+        self._analysis = _validated_setter(analysis)
 
     @property
     def Settings(self) -> _ZOSAPI.Analysis.Settings.IAS_:  # noqa: N802
         """Analysis-specific settings."""
-        return self._analysis.GetSettings()
+        return _validated_setter(self._analysis.GetSettings())
 
     @property
     def Results(self) -> _ZOSAPI.Analysis.Data.IAR_:  # noqa: N802

--- a/zospy/analyses/new/mtf/fft_through_focus_mtf.py
+++ b/zospy/analyses/new/mtf/fft_through_focus_mtf.py
@@ -9,6 +9,7 @@ from pydantic import Field
 
 from zospy.analyses.new.base import BaseAnalysisWrapper
 from zospy.analyses.new.decorators import analysis_settings
+from zospy.analyses.new.parsers.types import ZOSAPIConstant
 from zospy.api import constants
 from zospy.utils.zputils import standardize_sampling
 
@@ -50,7 +51,7 @@ class FFTThroughFocusMTFSettings:
         default="All", description="Wavelength number or 'All'"
     )
     field: Literal["All"] | Annotated[int, Field(gt=0)] = Field(default="All", description="Field number or 'All'")
-    mtf_type: str = Field(default="Modulation", description="MTF type")
+    mtf_type: ZOSAPIConstant("Analysis.Settings.Mtf.MtfTypes") = Field(default="Modulation", description="MTF type")
     use_polarization: bool = Field(default=False, description="Use polarization")
     use_dashes: bool = Field(default=False, description="Use dashes")
 

--- a/zospy/analyses/new/mtf/fft_through_focus_mtf.py
+++ b/zospy/analyses/new/mtf/fft_through_focus_mtf.py
@@ -96,7 +96,7 @@ class FFTThroughFocusMTF(BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughF
         self.analysis.Settings.NumberOfSteps = self.settings.number_of_steps
         self.analysis.wavelength = self.settings.wavelength
         self.analysis.field = self.settings.field
-        self.analysis.Settings.MtfType = constants.process_constant(
+        self.analysis.Settings.Type = constants.process_constant(
             constants.Analysis.Settings.Mtf.MtfTypes, self.settings.mtf_type
         )
         self.analysis.Settings.UsePolarization = self.settings.use_polarization

--- a/zospy/analyses/new/mtf/huygens_mtf.py
+++ b/zospy/analyses/new/mtf/huygens_mtf.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from zospy.analyses.new.base import BaseAnalysisWrapper
 from zospy.analyses.new.decorators import analysis_settings
-from zospy.analyses.new.parsers.types import FieldNumber, WavelengthNumber  # noqa: TCH001
+from zospy.analyses.new.parsers.types import FieldNumber, WavelengthNumber, ZOSAPIConstant  # noqa: TCH001
 from zospy.api import constants
 from zospy.utils.zputils import standardize_sampling
 
@@ -53,7 +53,7 @@ class HuygensMtfSettings:
     image_delta: float = Field(default=0.0, description="Image delta")
     wavelength: WavelengthNumber = Field(default="All", description="Wavelength number or 'All'")
     field: FieldNumber = Field(default="All", description="Field number or 'All'")
-    mtf_type: str = Field(default="Modulation", description="MTF type")
+    mtf_type: ZOSAPIConstant("Analysis.Settings.Mtf.MtfTypes") = Field(default="Modulation", description="MTF type")
     maximum_frequency: float = Field(default=150.0, description="Maximum frequency")
     use_polarization: bool = Field(default=False, description="Use polarization")
     use_dashes: bool = Field(default=False, description="Use dashes")
@@ -75,7 +75,7 @@ class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings]):
         image_delta: float = 0.0,
         wavelength: int | str = "All",
         field: int | str = "All",
-        mtf_type: str = "Modulation",
+        mtf_type: constants.Analysis.Settings.Mtf.MtfTypes = "Modulation",
         maximum_frequency: float = 150.0,
         use_polarization: bool = False,
         use_dashes: bool = False,
@@ -95,7 +95,7 @@ class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings]):
         self.analysis.Settings.ImageDelta = self.settings.image_delta
         self.analysis.wavelength = self.settings.wavelength
         self.analysis.field = self.settings.field
-        self.analysis.Settings.Type = self.settings.mtf_type
+        self.analysis.Settings.Type = constants.process_constant(constants.Analysis.Settings.Mtf.MtfTypes, self.settings.mtf_type)
         self.analysis.Settings.MaximumFrequency = self.settings.maximum_frequency
         self.analysis.Settings.UsePolarization = self.settings.use_polarization
         self.analysis.Settings.UseDashes = self.settings.use_dashes

--- a/zospy/analyses/new/mtf/huygens_mtf.py
+++ b/zospy/analyses/new/mtf/huygens_mtf.py
@@ -53,7 +53,7 @@ class HuygensMtfSettings:
     image_delta: float = Field(default=0.0, description="Image delta")
     wavelength: WavelengthNumber = Field(default="All", description="Wavelength number or 'All'")
     field: FieldNumber = Field(default="All", description="Field number or 'All'")
-    mtf_type: ZOSAPIConstant("Analysis.Settings.Mtf.MtfTypes") = Field(default="Modulation", description="MTF type")
+    mtf_type: ZOSAPIConstant("Analysis.Settings.Mtf.HuygensMtfTypes") = Field(default="Modulation", description="MTF type")
     maximum_frequency: float = Field(default=150.0, description="Maximum frequency")
     use_polarization: bool = Field(default=False, description="Use polarization")
     use_dashes: bool = Field(default=False, description="Use dashes")
@@ -75,7 +75,7 @@ class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings]):
         image_delta: float = 0.0,
         wavelength: int | str = "All",
         field: int | str = "All",
-        mtf_type: constants.Analysis.Settings.Mtf.MtfTypes = "Modulation",
+        mtf_type: constants.Analysis.Settings.Mtf.HuygensMtfTypes = "Modulation",
         maximum_frequency: float = 150.0,
         use_polarization: bool = False,
         use_dashes: bool = False,
@@ -95,7 +95,7 @@ class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings]):
         self.analysis.Settings.ImageDelta = self.settings.image_delta
         self.analysis.wavelength = self.settings.wavelength
         self.analysis.field = self.settings.field
-        self.analysis.Settings.Type = constants.process_constant(constants.Analysis.Settings.Mtf.MtfTypes, self.settings.mtf_type)
+        self.analysis.Settings.Type = constants.process_constant(constants.Analysis.Settings.Mtf.HuygensMtfTypes, self.settings.mtf_type)
         self.analysis.Settings.MaximumFrequency = self.settings.maximum_frequency
         self.analysis.Settings.UsePolarization = self.settings.use_polarization
         self.analysis.Settings.UseDashes = self.settings.use_dashes

--- a/zospy/analyses/new/surface/curvature.py
+++ b/zospy/analyses/new/surface/curvature.py
@@ -114,7 +114,7 @@ class Curvature(BaseAnalysisWrapper[CurvatureResult, CurvatureSettings]):
         )
         self.analysis.surface = self.settings.surface
         self.analysis.Settings.ShowAs = constants.process_constant(constants.Analysis.ShowAs, self.settings.show_as)
-        self.analysis.Settings.OffAxisCoordinates = self.settings.off_axis_coordinates
+        self.analysis.Settings.ConsiderOffAxisAperture = self.settings.off_axis_coordinates
 
         if self.analysis.Settings.ShowAs == constants.Analysis.ShowAs.Contour:
             self.analysis.Settings.ContourFormat = self.settings.contour_format


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

When non-existent attributes are set on Python.NET objects, they are monkey patched, i.e. the attribute is set on the Python representation of the object instead of raising an `AttributeError`. This allows typos in e.g. analysis settings to go unnoticed. #105 implements a unit test checking for this, but as this relies on parsing function definitions, some edge cases may still not be detected with this test.
`zospy.analyses.new.base.Analysis` now wraps OpticStudio analysis objects and their settings objects in a 'proxy class' that validates if attributes actually exist before they are set. Setting a non-existent attribute now raises an `AttributeError` instead of failing silently.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: ...
- OpticStudio version: ...

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I added new tests for any features contributed, or updated existing tests.
- [x] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
