### PR TITLE
Refactor ZOSPy core and remove deprecated functions

### DIFF
--- a/scripts/generate_test_reference_data/__main__.py
+++ b/scripts/generate_test_reference_data/__main__.py
@@ -167,13 +167,13 @@ def process_test(
     test_parameters = test.parameters
     parametrized = test.parametrized
 
-    optic_studio_version = str(oss._ZOS.version)  # noqa: SLF001
+    optic_studio_version = str(oss.ZOS.version)  # noqa: SLF001
 
     for parameters in test_parameters:
         result_file_name = f"{optic_studio_version}-{test_file}-{test_name}"
 
         if isinstance(parameters, VersionDependentParameters):
-            if not oss._ZOS.version.match(parameters.opticstudio):  # noqa: SLF001
+            if not oss.ZOS.version.match(parameters.opticstudio):  # noqa: SLF001
                 logger.info(f"Skipping {result_file_name} because it requires OpticStudio {parameters.opticstudio}")
                 continue
 

--- a/scripts/generate_test_reference_data/__main__.py
+++ b/scripts/generate_test_reference_data/__main__.py
@@ -167,13 +167,13 @@ def process_test(
     test_parameters = test.parameters
     parametrized = test.parametrized
 
-    optic_studio_version = str(oss.ZOS.version)  # noqa: SLF001
+    optic_studio_version = str(oss.ZOS.version)
 
     for parameters in test_parameters:
         result_file_name = f"{optic_studio_version}-{test_file}-{test_name}"
 
         if isinstance(parameters, VersionDependentParameters):
-            if not oss.ZOS.version.match(parameters.opticstudio):  # noqa: SLF001
+            if not oss.ZOS.version.match(parameters.opticstudio):
                 logger.info(f"Skipping {result_file_name} because it requires OpticStudio {parameters.opticstudio}")
                 continue
 

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -188,17 +188,17 @@ class TestTxtFileEncoding:
         else:
             monkeypatch.setattr(locale, "getencoding", getencoding)
 
-        oss_with_modifiable_config._ZOS.Application.Preferences.General.TXTFileEncoding = getattr(
+        oss_with_modifiable_config.ZOS.Application.Preferences.General.TXTFileEncoding = getattr(
             constants.Preferences.EncodingType, txtfile_encoding
         )
 
-        returned_encoding = oss_with_modifiable_config._ZOS.get_txtfile_encoding()
+        returned_encoding = oss_with_modifiable_config.ZOS.get_txtfile_encoding()
 
         assert returned_encoding == expected_encoding
 
     @pytest.mark.parametrize("txtfile_encoding", ["Unicode", "ANSI"])
     def test_analysis_result_parsed_with_correct_encoding(self, oss_with_modifiable_config, txtfile_encoding, tmp_path):
-        oss_with_modifiable_config._ZOS.Application.Preferences.General.TXTFileEncoding = getattr(
+        oss_with_modifiable_config.ZOS.Application.Preferences.General.TXTFileEncoding = getattr(
             constants.Preferences.EncodingType, txtfile_encoding
         )
 
@@ -209,5 +209,5 @@ class TestTxtFileEncoding:
         txtoutfile = str(tmp_path / "test_analysis_result_parsed_with_correct_encoding.txt")
         analysis.Results.GetTextFile(txtoutfile)
 
-        with open(txtoutfile, encoding=oss_with_modifiable_config._ZOS.get_txtfile_encoding()) as txtfile:
+        with open(txtoutfile, encoding=oss_with_modifiable_config.ZOS.get_txtfile_encoding()) as txtfile:
             assert "System/Prescription Data" in txtfile.readline()

--- a/tests/utils/test_pyutils.py
+++ b/tests/utils/test_pyutils.py
@@ -236,7 +236,7 @@ class TestStringToNumberConversion:
         # Get results
         analysis.Results.GetTextFile(txtoutfile)
 
-        with open(txtoutfile, encoding=simple_system._ZOS.get_txtfile_encoding()) as f:  # noqa: SLF001
+        with open(txtoutfile, encoding=simple_system.ZOS.get_txtfile_encoding()) as f:  # noqa: SLF001
             text_output = f.read()
 
         xphase_out = atox(_get_number_field("X-Phase", text_output), dtype=float)

--- a/tests/utils/test_pyutils.py
+++ b/tests/utils/test_pyutils.py
@@ -236,7 +236,7 @@ class TestStringToNumberConversion:
         # Get results
         analysis.Results.GetTextFile(txtoutfile)
 
-        with open(txtoutfile, encoding=simple_system.ZOS.get_txtfile_encoding()) as f:  # noqa: SLF001
+        with open(txtoutfile, encoding=simple_system.ZOS.get_txtfile_encoding()) as f:
             text_output = f.read()
 
         xphase_out = atox(_get_number_field("X-Phase", text_output), dtype=float)

--- a/zospy/analyses/mtf.py
+++ b/zospy/analyses/mtf.py
@@ -31,7 +31,7 @@ def _correct_fft_through_focus_mtftype_api_bug(oss, analysis, mtftype) -> None:
     -------
     None
     """
-    if oss._ZOS.version < "21.2.0":
+    if oss.ZOS.version < "21.2.0":
         fd, cfgoutfile = mkstemp(suffix=".CFG", prefix="zospy_")
         os.close(fd)
         analysis.Settings.SaveTo(cfgoutfile)

--- a/zospy/analyses/new/base.py
+++ b/zospy/analyses/new/base.py
@@ -596,7 +596,7 @@ class BaseAnalysisWrapper(ABC, Generic[AnalysisData, AnalysisSettings]):
         """Get the text output of the analysis."""
         self.analysis.Results.GetTextFile(str(self.text_output_file))
 
-        with open(self._text_output_file, encoding=self.oss.ZOS.get_txtfile_encoding()) as f:  # noqa: SLF001
+        with open(self._text_output_file, encoding=self.oss.ZOS.get_txtfile_encoding()) as f:
             return f.read()
 
     def _create_analysis(self, *, settings_first=True):

--- a/zospy/analyses/new/base.py
+++ b/zospy/analyses/new/base.py
@@ -596,7 +596,7 @@ class BaseAnalysisWrapper(ABC, Generic[AnalysisData, AnalysisSettings]):
         """Get the text output of the analysis."""
         self.analysis.Results.GetTextFile(str(self.text_output_file))
 
-        with open(self._text_output_file, encoding=self.oss._ZOS.get_txtfile_encoding()) as f:  # noqa: SLF001
+        with open(self._text_output_file, encoding=self.oss.ZOS.get_txtfile_encoding()) as f:  # noqa: SLF001
             return f.read()
 
     def _create_analysis(self, *, settings_first=True):

--- a/zospy/analyses/new/mtf/fft_through_focus_mtf.py
+++ b/zospy/analyses/new/mtf/fft_through_focus_mtf.py
@@ -119,7 +119,7 @@ class FFTThroughFocusMTF(BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughF
         -------
         None
         """
-        if self.oss._ZOS.version < "21.2.0":  # noqa: SLF001
+        if self.oss.ZOS.version < "21.2.0":  # noqa: SLF001
             config_file = str(self.config_file)
 
             self.analysis.Settings.SaveTo(config_file)

--- a/zospy/analyses/new/mtf/fft_through_focus_mtf.py
+++ b/zospy/analyses/new/mtf/fft_through_focus_mtf.py
@@ -119,7 +119,7 @@ class FFTThroughFocusMTF(BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughF
         -------
         None
         """
-        if self.oss.ZOS.version < "21.2.0":  # noqa: SLF001
+        if self.oss.ZOS.version < "21.2.0":
             config_file = str(self.config_file)
 
             self.analysis.Settings.SaveTo(config_file)

--- a/zospy/analyses/new/systemviewers/base.py
+++ b/zospy/analyses/new/systemviewers/base.py
@@ -188,7 +188,7 @@ class SystemViewerWrapper(BaseAnalysisWrapper[np.ndarray | None, AnalysisSetting
 
         image_data = None
 
-        if self.oss.ZOS.version >= (24, 1, 0):  # noqa: SLF001
+        if self.oss.ZOS.version >= (24, 1, 0):
             self._close_current_tool()
             image_data = self.run_analysis()
         else:

--- a/zospy/analyses/new/systemviewers/base.py
+++ b/zospy/analyses/new/systemviewers/base.py
@@ -188,7 +188,7 @@ class SystemViewerWrapper(BaseAnalysisWrapper[np.ndarray | None, AnalysisSetting
 
         image_data = None
 
-        if self.oss._ZOS.version >= (24, 1, 0):  # noqa: SLF001
+        if self.oss.ZOS.version >= (24, 1, 0):  # noqa: SLF001
             self._close_current_tool()
             image_data = self.run_analysis()
         else:

--- a/zospy/analyses/polarization.py
+++ b/zospy/analyses/polarization.py
@@ -164,7 +164,7 @@ def polarization_pupil_map(
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
 
-    with open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding()) as f:
+    with open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding()) as f:
         text_output = f.read()
         line_list = text_output.split("\n")
 
@@ -362,7 +362,7 @@ def transmission(
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
 
-    with open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding()) as f:
+    with open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding()) as f:
         text_output = f.read()
         line_list = text_output.split("\n")
 

--- a/zospy/analyses/raysandspots.py
+++ b/zospy/analyses/raysandspots.py
@@ -166,7 +166,7 @@ def single_ray_trace(
 
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
-    line_list = [line for line in open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding())]
+    line_list = [line for line in open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding())]
     data = _structure_ray_trace_data_result(line_list)
 
     # Get headerdata, metadata and messages

--- a/zospy/analyses/reports.py
+++ b/zospy/analyses/reports.py
@@ -224,7 +224,7 @@ def surface_data(
 
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
-    line_list = [line for line in open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding())]
+    line_list = [line for line in open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding())]
     data = _structure_surface_data_result(line_list)
 
     # Get headerdata, metadata and messages
@@ -313,7 +313,7 @@ def surface_data_fromcfg(
 
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
-    line_list = [line for line in open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding())]
+    line_list = [line for line in open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding())]
     data = _structure_surface_data_result(line_list)
 
     # Get headerdata, metadata and messages
@@ -607,7 +607,7 @@ def system_data(
 
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
-    line_list = [line for line in open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding())]
+    line_list = [line for line in open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding())]
     data = _structure_system_data_result(line_list)
 
     # Get headerdata, metadata and messages
@@ -831,7 +831,7 @@ def cardinal_points(
 
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
-    line_list = [line for line in open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding())]
+    line_list = [line for line in open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding())]
     data = _structure_cardinal_point_result(line_list)
 
     # Get headerdata, metadata and messages
@@ -918,7 +918,7 @@ def cardinal_points_fromcfg(
 
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
-    line_list = [line for line in open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding())]
+    line_list = [line for line in open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding())]
     data = _structure_cardinal_point_result(line_list)
 
     # Get headerdata, metadata and messages

--- a/zospy/analyses/systemviewers.py
+++ b/zospy/analyses/systemviewers.py
@@ -43,7 +43,7 @@ def _warn_specified_parameters(
     >>> def test_func(a=1, b=2, c=3):
     ...     _warn_specified_parameters(oss, locals(), test_func)
     """
-    if oss._ZOS.version >= (24, 1, 0):
+    if oss.ZOS.version >= (24, 1, 0):
         return
 
     changed_parameters = []
@@ -218,7 +218,7 @@ def cross_section(
 
     analysis = new_analysis(oss, analysis_type, settings_first=False)
 
-    if oss._ZOS.version >= (24, 1, 0):
+    if oss.ZOS.version >= (24, 1, 0):
         _close_current_tool(oss)
 
         layout_tool = oss.Tools.Layouts.OpenCrossSectionExport()
@@ -408,7 +408,7 @@ def viewer_3d(
 
     analysis = new_analysis(oss, analysis_type, settings_first=False)
 
-    if oss._ZOS.version >= (24, 1, 0):
+    if oss.ZOS.version >= (24, 1, 0):
         _close_current_tool(oss)
 
         layout_tool = oss.Tools.Layouts.Open3DViewerExport()

--- a/zospy/analyses/wavefront.py
+++ b/zospy/analyses/wavefront.py
@@ -316,7 +316,7 @@ def zernike_standard_coefficients(
 
     # Get results
     analysis.Results.GetTextFile(txtoutfile)
-    line_list = [line for line in open(txtoutfile, "r", encoding=oss._ZOS.get_txtfile_encoding())]
+    line_list = [line for line in open(txtoutfile, "r", encoding=oss.ZOS.get_txtfile_encoding())]
 
     general_data, zernike_data = _structure_zernike_standard_coefficients_result(line_list)
     data = AttrDict(GeneralData=general_data, Coefficients=zernike_data)

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from warnings import warn
-
 from zospy.api import _ZOSAPI, constants
 
 

--- a/zospy/functions/nce.py
+++ b/zospy/functions/nce.py
@@ -105,39 +105,3 @@ def find_object_by_comment(
 
     # Return list of objects with matching comment
     return matching_objects
-
-
-def get_object_data(obj: _ZOSAPI.Editors.NCE.INCERow) -> _ZOSAPI.Editors.NCE.IObject:
-    """Get the object-specific data.
-
-    .. deprecated:: 1.2.0
-            `get_object_data` will be removed in ZOSPy 2.0.0, as this conversion is now implemented in
-            `zospy.api.codecs`.
-
-    Parameters
-    ----------
-    obj : ZOSAPI.Editors.NCE.INCERow
-        The Row/Object for which the data is requested.
-
-    Returns
-    -------
-    ZOSAPI.Editors.NCE.IObject
-        The object-specific data with the inherited implementation.
-
-    Examples
-    --------
-    >>> import zospy as zp
-    >>> zos = zp.ZOS()
-    >>> oss = zos.connect()
-    >>> oss.make_nonsequential()
-    >>> detector_object = oss.NCE.GetObjectAt(1)
-    >>> detector_type = detector_object.GetObjectTypeSettings(
-    ...     zp.constants.Editors.NCE.ObjectType.DetectorRectangle
-    ... )
-    >>> detector_object.ChangeType(detector_type)
-    >>> detector_data = zp.functions.nce.get_object_data(detector_object)
-    >>> number_of_x_pixels = detector_data.NumberXPixels
-    """
-    warn("'get_object_data' is deprecated and will be removed in ZOSPy 2.0.0.", DeprecationWarning, stacklevel=1)
-
-    return obj.ObjectData

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -308,7 +308,7 @@ class OpticStudioSystem:
         zospy.zpcore.OpticStudioSystem
             A ZOSPy OpticStudioSystem instance. Should be sequential.
         """
-        return OpticStudioSystem(self._ZOS, self._System.CopySystem())
+        return OpticStudioSystem(self.ZOS, self._System.CopySystem())
 
     def _ensure_correct_mode(self, required: str):
         """Ensure that the system is in the required type.
@@ -344,7 +344,8 @@ class ZOS:
     """A Communication instance for Zemax OpticStudio.
 
     This class manages the connection between Python and Zemax OpticStudio through .NET, and controls OpticStudio
-    instances. Only one instance of `ZOS` can exist at any time.
+    instances. Only one instance of `ZOS` can exist at any time. If a second instance is attempted to be created, the
+    existing instance is returned.
 
     Parameters
     ----------
@@ -364,11 +365,6 @@ class ZOS:
         The ZOSAPI interface once loaded, else `None`.
     ZOSAPI_NetHelper : None | netModuleObject
         The ZOSAPI_NetHelper interface once loaded, else `None`.
-
-    Raises
-    ------
-    ValueError
-        When it is attempted to initiate a second instance of  `ZOS`. Only one instance can exist at any time.
 
     Examples
     --------
@@ -397,7 +393,8 @@ class ZOS:
         If a ZOS instance already exists, the existing instance is returned. If not, a new instance is created.
         """
         if cls not in cls._instances:
-            cls._instances[cls] = super().__new__(cls)
+            instance = super().__new__(cls)
+            cls._instances[cls] = instance
         else:
             warnings.warn("Only a single instance of ZOS can exist at any time. Returning existing instance.")
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -52,7 +52,8 @@ class OpticStudioSystem:
         system_instance : ZOS.Application.PrimarySystem
             A PrimarySystem instance obtained from the zos_instance.
         """
-        self._ZOS: ZOS = zos_instance
+        # Use weakref to make sure that the ZOS instance is not kept alive by the OpticStudioSystem instance
+        self.ZOS: ZOS = weakref.proxy(zos_instance)
 
         self._System: _ZOSAPI.IOpticalSystem = system_instance
         self._OpenFile = None


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

`zpcore` has been refactored and deprecated methods in `zospy.zpcore` and `zospy.functions` have been removed.

Notable changes:

- `ZOS` is now a singleton. Calling `zospy.ZOS` for the second time will raise a warning and return the existing instance. I used a `weakref.WeakValueDictionary` to store the existing instance. Because the dictionary will at most contain a single value, using a `weakref.ref` object would be possible as well, but this would require explicitly setting the value to `None` on initialization and deletion. The current implementation will automatically empty the dictionary. Alternatively, a `weakref.WeakSet` would work as well, but retrieving a single value from a dictionary is a bit easier than retrieving it from a set. **Please explain which option you prefer as part of the review.**
- `ZOS` has a new classmethod `get_instance` that allows to get an existing instance if available. Unlike `__init__`, calling this method will not create a new instance. This method could for instance be used to make the `oss` parameter for analyses optional, automatically using the primary system of a connected instance if `oss` is not specified.
- `OpticStudioSystem._ZOS` was renamed to `ZOS`, making it public. We use it quite a lot outside `OpticStudioSystem` itself, e.g. to check for the OpticStudio version, so I think it makes sense to make it a public attribute. Alternatively, we may opt for adding a separate `version` attribute to `OpticStudioSystem`. **Please comment on this as part of the review.**
- `OpticStudioSystem.ZOS` is now a `weakref.proxy` object, so removing the `ZOS` instance (e.g. with `del zos`) will work without first removing the `OpticStudioSystem` instance. Previously, `oss` blocked the garbage collector from deleting `ZOS` instances if there were still `OpticStudioSystem` instances around, see #61.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.12
- OpticStudio version: 24R2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [ ] The code has been linted, formatted and tested locally using tox.
- [ ] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
