### PR TITLE
Refactor the way analysis settings are set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ path = "zospy/__init__.py"
 python = "3.12"
 installer = "uv"
 path = ".venv"
+dependencies = ["pytest"]
+
 
 [tool.hatch.envs.default.scripts]
 test-extension = "hatch test --extension {args}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,17 @@ build-backend = "hatchling.build"
 [project]
 name = "zospy"
 authors = [
-    {name = "Luc van Vught"},
-    {name = "Jan-Willem Beenakker"},
-    {name = "Corné Haasjes"}
+    { name = "Luc van Vught" },
+    { name = "Jan-Willem Beenakker" },
+    { name = "Corné Haasjes" }
 ]
 maintainers = [
-    {name = "MReye research group", email = "zospy@mreye.nl"}
+    { name = "MReye research group", email = "zospy@mreye.nl" }
 ]
 
 description = "A Python package used to communicate with Zemax OpticStudio through the API"
 readme = "README.md"
-license = {file = "LICENSE.txt"}
+license = { file = "LICENSE.txt" }
 keywords = ["Zemax", "OpticStudio", "API", "ZOSAPI"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -30,7 +30,8 @@ dependencies = [
     "pydantic >= 2.4.0",
     "numpy",
     "semver >= 3.0.0,<4",
-    "eval_type_backport", # TODO: Remove when dropping support for Python 3.9
+    "eval_type_backport; python_version <= '3.9'", # TODO: Remove when dropping support for Python 3.9
+    "typing_extensions; python_version <= '3.10'"
 ]
 dynamic = ["version"]
 
@@ -57,6 +58,7 @@ path = "zospy/__init__.py"
 [tool.hatch.envs.default]
 python = "3.12"
 installer = "uv"
+path = ".venv"
 
 [tool.hatch.envs.default.scripts]
 test-extension = "hatch test --extension {args}"
@@ -118,7 +120,6 @@ extend-include = [
 exclude = [
     "zospy/api/_ZOSAPI",
     "zospy/api/_ZOSAPI_constants",
-
     # TODO: Change this when movind the old analyses to zospy.analyses.old
     "zospy/analyses/base.py",
     "zospy/analyses/extendedscene.py",

--- a/tests/analyses/new/parsers/test_types.py
+++ b/tests/analyses/new/parsers/test_types.py
@@ -82,11 +82,11 @@ class TestValidatedNDArray:
             validated_ndarray.validate_python([[1, 2, 3], [4, 5]])
 
 
-class TestZOSAPIConstant:
-    @staticmethod
-    def _get_instances():
-        return [obj for obj in gc.get_objects() if isinstance(obj, ZOSAPIConstantAnnotation)]
+def _get_zosapi_constant_instances():
+    return [obj for obj in gc.get_objects() if isinstance(obj, ZOSAPIConstantAnnotation)]
 
+
+class TestZOSAPIConstant:
     @staticmethod
     def _hasattr(obj, attr):
         for name in attr.split("."):
@@ -97,6 +97,6 @@ class TestZOSAPIConstant:
 
         return True
 
-    @pytest.mark.parametrize("annotation", _get_instances())
+    @pytest.mark.parametrize("annotation", _get_zosapi_constant_instances())
     def test_constant_exists(self, zos, annotation):  # noqa: ARG002
         assert self._hasattr(constants, annotation.enum)

--- a/tests/analyses/new/test_base.py
+++ b/tests/analyses/new/test_base.py
@@ -172,14 +172,14 @@ class TestAnalysisWrapper:
 
     def test_change_settings_from_object(self):
         settings = MockAnalysisSettings(int_setting=2, string_setting="b")
-        analysis = MockAnalysis.from_settings(settings)
+        analysis = MockAnalysis.with_settings(settings)
 
         assert analysis.settings.int_setting == 2
         assert analysis.settings.string_setting == "b"
 
     def test_settings_object_is_copied(self):
         settings = MockAnalysisSettings(int_setting=2, string_setting="b")
-        analysis = MockAnalysis.from_settings(settings)
+        analysis = MockAnalysis.with_settings(settings)
 
         assert analysis.settings is not settings
         assert analysis.settings == settings

--- a/tests/analyses/new/test_base.py
+++ b/tests/analyses/new/test_base.py
@@ -108,6 +108,10 @@ class TestAnalysisWrapper:
         assert hasattr(constants.Analysis.AnalysisIDM, cls.TYPE)
 
     @pytest.mark.parametrize("cls", analysis_wrapper_classes)
+    def test_init_all_keyword_only_parameters(self, cls):
+        all(p.kind.name == "KEYWORD_ONLY" for _, p in inspect.signature(cls).parameters.items())
+
+    @pytest.mark.parametrize("cls", analysis_wrapper_classes)
     def test_init_contains_all_settings(self, cls):
         if cls().settings is None:
             return

--- a/tests/analyses/new/test_base.py
+++ b/tests/analyses/new/test_base.py
@@ -47,8 +47,14 @@ class MockAnalysis(BaseAnalysisWrapper[MockAnalysisData, MockAnalysisSettings]):
     _needs_config_file = False
     _needs_text_output_file = False
 
-    def __init__(self, int_setting: int = 1, string_setting: str = "a", settings: MockAnalysisSettings | None = None,
-                 *, block_remove_temp_files: bool = False):
+    def __init__(
+        self,
+        int_setting: int = 1,
+        string_setting: str = "a",
+        settings: MockAnalysisSettings | None = None,
+        *,
+        block_remove_temp_files: bool = False,
+    ):
         super().__init__(settings or MockAnalysisSettings(), locals())
 
         self.block_remove_temp_files = block_remove_temp_files

--- a/tests/analyses/new/test_base.py
+++ b/tests/analyses/new/test_base.py
@@ -184,6 +184,36 @@ class TestAnalysisWrapper:
         assert analysis.settings is not settings
         assert analysis.settings == settings
 
+    def test_update_settings_object(self):
+        analysis = MockAnalysis(int_setting=1, string_setting="a")
+
+        analysis.update_settings(settings=MockAnalysisSettings(int_setting=2, string_setting="b"))
+
+        assert analysis.settings.int_setting == 2
+        assert analysis.settings.string_setting == "b"
+
+    def test_update_settings_dictionary(self):
+        analysis = MockAnalysis(int_setting=1, string_setting="a")
+
+        analysis.update_settings(settings_kws={"int_setting": 2, "string_setting": "b"})
+
+        assert analysis.settings.int_setting == 2
+        assert analysis.settings.string_setting == "b"
+
+    def test_update_settings_object_and_dictionary(self):
+        analysis = MockAnalysis(int_setting=1, string_setting="a")
+
+        analysis.update_settings(
+            settings=MockAnalysisSettings(int_setting=2, string_setting="a"), settings_kws={"string_setting": "b"}
+        )
+
+        assert analysis.settings.int_setting == 2
+        assert analysis.settings.string_setting == "b"
+
+    def test_update_settings_no_dataclass_raises_type_error(self):
+        with pytest.raises(TypeError, match="settings should be a dataclass"):
+            MockAnalysis().update_settings(settings=123)
+
     @pytest.mark.parametrize(
         "temp_file_type,filename",
         [

--- a/tests/analyses/new/test_systemviewers.py
+++ b/tests/analyses/new/test_systemviewers.py
@@ -27,7 +27,7 @@ class TestBase:
 
     class MockSystemViewer(SystemViewerWrapper[MockSystemViewerSettings]):
         def __init__(self, *, number: int = 5, settings: TestBase.MockSystemViewerSettings | None = None):
-            super().__init__(settings or TestBase.MockSystemViewerSettings(), locals())
+            super().__init__(locals())
 
         def _create_analysis(self, *, settings_first=True):  # noqa: ARG002
             self._analysis = SimpleNamespace(

--- a/zospy/analyses/base.py
+++ b/zospy/analyses/base.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from enum import Enum
 from importlib import import_module
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -564,12 +564,12 @@ class Analysis:
 
         return "All" if wavelength == 0 else wavelength
 
-    def set_surface(self, value: int | str):
+    def set_surface(self, value: int | Literal["Image", "Objective", "Object"]):
         """Sets the surface value for the analysis.
 
         Parameters
         ----------
-        value : int or str
+        value : int or Literal["Image", "Objective", "Object"]
             The value to which the surface should be set. Either int or str. Accepts only 'Image' or 'Objective' as
             string.
 
@@ -581,11 +581,11 @@ class Analysis:
         ------
         ValueError
             When 'value' is not integer or string. When it is a string, it also raises an error when the string does not
-            equal 'Image' or 'Objective'.
+            equal 'Image', 'Objective' or 'Object'.
         """
         if value == "Image":
             self.Settings.Surface.UseImageSurface()
-        elif value == "Objective":
+        elif value in ("Object", "Objective"):
             self.Settings.Surface.UseObjectiveSurface()
         elif isinstance(value, int):
             self.Settings.Surface.SetSurfaceNumber(value)

--- a/zospy/analyses/new/base.py
+++ b/zospy/analyses/new/base.py
@@ -548,7 +548,7 @@ class BaseAnalysisWrapper(ABC, Generic[AnalysisData, AnalysisSettings]):
     def __init__(self, *, settings_kws: dict[str, any] | None = None):
         """Create a new analysis wrapper.
 
-        Settings can be changed by passing the settings as keyword arguments. Use the `from_settings` method to specify
+        Settings can be changed by passing the settings as keyword arguments. Use the `with_settings` method to specify
         the settings using a settings object.
 
         Parameters
@@ -644,7 +644,7 @@ class BaseAnalysisWrapper(ABC, Generic[AnalysisData, AnalysisSettings]):
         return cls._settings_type() if cls._settings_type is not None else None
 
     @classmethod
-    def from_settings(cls, settings: AnalysisSettings):
+    def with_settings(cls, settings: AnalysisSettings):
         """Create a new analysis with the specified settings.
 
         Parameters

--- a/zospy/analyses/new/base.py
+++ b/zospy/analyses/new/base.py
@@ -36,7 +36,6 @@ from enum import Enum
 from importlib import import_module
 from pathlib import Path
 from tempfile import mkstemp
-from types import NoneType
 from typing import TYPE_CHECKING, Generic, Literal, TypedDict, TypeVar, cast, get_args
 
 import numpy as np
@@ -593,7 +592,7 @@ class BaseAnalysisWrapper(ABC, Generic[AnalysisData, AnalysisSettings]):
                 base = cls.__orig_bases__[0]
                 cls._settings_type: type[AnalysisSettings] = get_args(base)[1]
             else:
-                cls._settings_type = NoneType
+                cls._settings_type = type(None)  # TODO: change to NoneType when dropping support for Python 3.9
 
         super().__init_subclass__(**kwargs)
 

--- a/zospy/analyses/new/decorators.py
+++ b/zospy/analyses/new/decorators.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import dataclass_transform
+from sys import version_info
 
 import pydantic
 from pydantic import ConfigDict, Field, PrivateAttr
+
+if version_info <= (3, 11):
+    from typing_extensions import dataclass_transform
+else:
+    from typing import dataclass_transform
 
 
 @dataclass_transform(field_specifiers=(dataclasses.field, Field, PrivateAttr))

--- a/zospy/analyses/new/extendedscene/geometric_image_analysis.py
+++ b/zospy/analyses/new/extendedscene/geometric_image_analysis.py
@@ -109,8 +109,7 @@ class GeometricImageAnalysisSettings:
 
 
 class GeometricImageAnalysis(
-    BaseAnalysisWrapper[Union[DataFrame, None], GeometricImageAnalysisSettings],
-    analysis_type="GeometricImageAnalysis"
+    BaseAnalysisWrapper[Union[DataFrame, None], GeometricImageAnalysisSettings], analysis_type="GeometricImageAnalysis"
 ):
     """Geometric Image Analysis."""
 

--- a/zospy/analyses/new/extendedscene/geometric_image_analysis.py
+++ b/zospy/analyses/new/extendedscene/geometric_image_analysis.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Union
 
 from pandas import DataFrame
 from pydantic import Field
@@ -108,13 +108,11 @@ class GeometricImageAnalysisSettings:
     save_as_bim_file: str = Field(default="", description="Filename used to save output as BIM file")
 
 
-class GeometricImageAnalysis(BaseAnalysisWrapper[DataFrame | None, GeometricImageAnalysisSettings]):
+class GeometricImageAnalysis(
+    BaseAnalysisWrapper[Union[DataFrame, None], GeometricImageAnalysisSettings],
+    analysis_type="GeometricImageAnalysis"
+):
     """Geometric Image Analysis."""
-
-    TYPE = "GeometricImageAnalysis"
-
-    _needs_config_file = False
-    _needs_text_output_file = False
 
     def __init__(
         self,
@@ -150,7 +148,7 @@ class GeometricImageAnalysis(BaseAnalysisWrapper[DataFrame | None, GeometricImag
         --------
         GeometricImageAnalysisSettings : Settings for the Geometric Image Analysis analysis.
         """
-        super().__init__(settings or GeometricImageAnalysisSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> DataFrame | None:
         """Run the FFT Through Focus MTF analysis."""

--- a/zospy/analyses/new/mtf/fft_through_focus_mtf.py
+++ b/zospy/analyses/new/mtf/fft_through_focus_mtf.py
@@ -13,6 +13,8 @@ from zospy.analyses.new.parsers.types import ZOSAPIConstant  # noqa: TCH001
 from zospy.api import constants
 from zospy.utils.zputils import standardize_sampling
 
+__all__ = ("FFTThroughFocusMTF", "FFTThroughFocusMTFSettings")
+
 
 @analysis_settings
 class FFTThroughFocusMTFSettings:

--- a/zospy/analyses/new/mtf/fft_through_focus_mtf.py
+++ b/zospy/analyses/new/mtf/fft_through_focus_mtf.py
@@ -55,13 +55,12 @@ class FFTThroughFocusMTFSettings:
     use_dashes: bool = Field(default=False, description="Use dashes")
 
 
-class FFTThroughFocusMTF(BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughFocusMTFSettings]):
+class FFTThroughFocusMTF(
+    BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughFocusMTFSettings],
+    analysis_type="FftThroughFocusMtf",
+    needs_config_file=True,
+):
     """FFT Through Focus MTF analysis."""
-
-    TYPE = "FftThroughFocusMtf"
-
-    _needs_config_file = True
-    _needs_text_output_file = False
 
     def __init__(
         self,
@@ -75,7 +74,6 @@ class FFTThroughFocusMTF(BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughF
         mtf_type: constants.Analysis.Settings.Mtf.MtfTypes | str = "Modulation",
         use_polarization: bool = False,
         use_dashes: bool = False,
-        settings: FFTThroughFocusMTFSettings | None = None,
     ):
         """Create a new FFT Through Focus MTF analysis.
 
@@ -83,7 +81,7 @@ class FFTThroughFocusMTF(BaseAnalysisWrapper[Union[DataFrame, None], FFTThroughF
         --------
         FFTThroughFocusMTFSettings : Settings for the FFT Through Focus MTF analysis.
         """
-        super().__init__(settings or FFTThroughFocusMTFSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> DataFrame | None:
         """Run the FFT Through Focus MTF analysis."""

--- a/zospy/analyses/new/mtf/huygens_mtf.py
+++ b/zospy/analyses/new/mtf/huygens_mtf.py
@@ -59,13 +59,8 @@ class HuygensMtfSettings:
     use_dashes: bool = Field(default=False, description="Use dashes")
 
 
-class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings]):
+class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings], analysis_type="HuygensMtf"):
     """Huygens Modulation Transfer Function (MTF) analysis."""
-
-    TYPE = "HuygensMtf"
-
-    _needs_config_file = False
-    _needs_text_output_file = False
 
     def __init__(
         self,
@@ -79,10 +74,14 @@ class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings]):
         maximum_frequency: float = 150.0,
         use_polarization: bool = False,
         use_dashes: bool = False,
-        settings: HuygensMtfSettings | None = None,
     ):
-        """Create a new Huygens MTF analysis."""
-        super().__init__(settings or HuygensMtfSettings(), locals())
+        """Create a new Huygens MTF analysis.
+
+        See Also
+        --------
+        HuygensMtfSettings : Settings for the Huygens MTF analysis.
+        """
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> DataFrame | None:
         """Run the Huygens MTF analysis."""

--- a/zospy/analyses/new/mtf/huygens_mtf.py
+++ b/zospy/analyses/new/mtf/huygens_mtf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Union
 
 from pandas import DataFrame
 from pydantic import Field
@@ -61,7 +61,7 @@ class HuygensMtfSettings:
     use_dashes: bool = Field(default=False, description="Use dashes")
 
 
-class HuygensMTF(BaseAnalysisWrapper[DataFrame, HuygensMtfSettings], analysis_type="HuygensMtf"):
+class HuygensMTF(BaseAnalysisWrapper[Union[DataFrame, None], HuygensMtfSettings], analysis_type="HuygensMtf"):
     """Huygens Modulation Transfer Function (MTF) analysis."""
 
     def __init__(

--- a/zospy/analyses/new/physicaloptics/physical_optics_propagation.py
+++ b/zospy/analyses/new/physicaloptics/physical_optics_propagation.py
@@ -17,7 +17,12 @@ from zospy.utils.zputils import standardize_sampling
 if TYPE_CHECKING:
     from zospy.zpcore import OpticStudioSystem
 
-__all__ = ("PhysicalOpticsPropagation", "PhysicalOpticsPropagationSettings", "create_beam_parameter_dict", "create_fiber_parameter_dict")
+__all__ = (
+    "PhysicalOpticsPropagation",
+    "PhysicalOpticsPropagationSettings",
+    "create_beam_parameter_dict",
+    "create_fiber_parameter_dict",
+)
 
 
 @analysis_settings
@@ -240,7 +245,7 @@ class PhysicalOpticsPropagationSettings:
 class PhysicalOpticsPropagation(
     BaseAnalysisWrapper[Union[DataFrame, None], PhysicalOpticsPropagationSettings],
     analysis_type="PhysicalOpticsPropagation",
-    mode="Sequential"
+    mode="Sequential",
 ):
     """Physical Optics Propagation analysis."""
 

--- a/zospy/analyses/new/physicaloptics/physical_optics_propagation.py
+++ b/zospy/analyses/new/physicaloptics/physical_optics_propagation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal, Union
 from warnings import warn
 
 from pandas import DataFrame
@@ -16,6 +16,8 @@ from zospy.utils.zputils import standardize_sampling
 
 if TYPE_CHECKING:
     from zospy.zpcore import OpticStudioSystem
+
+__all__ = ("PhysicalOpticsPropagation", "PhysicalOpticsPropagationSettings", "create_beam_parameter_dict", "create_fiber_parameter_dict")
 
 
 @analysis_settings
@@ -235,11 +237,12 @@ class PhysicalOpticsPropagationSettings:
         return self
 
 
-class PhysicalOpticsPropagation(BaseAnalysisWrapper[PhysicalOpticsPropagationSettings, DataFrame]):
+class PhysicalOpticsPropagation(
+    BaseAnalysisWrapper[Union[DataFrame, None], PhysicalOpticsPropagationSettings],
+    analysis_type="PhysicalOpticsPropagation",
+    mode="Sequential"
+):
     """Physical Optics Propagation analysis."""
-
-    TYPE = "PhysicalOpticsPropagation"
-    MODE = "Sequential"
 
     def __init__(
         self,
@@ -292,7 +295,7 @@ class PhysicalOpticsPropagation(BaseAnalysisWrapper[PhysicalOpticsPropagationSet
         --------
         PhysicalOpticsPropagationSettings : Settings for the Physical Optics Propagation analysis.
         """
-        super().__init__(settings or PhysicalOpticsPropagationSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> DataFrame:
         """Run the Physical Optics Propagation analysis."""

--- a/zospy/analyses/new/polarization/pupil_map.py
+++ b/zospy/analyses/new/polarization/pupil_map.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Union
 
 import pandas as pd
 from pydantic import Field
@@ -85,7 +85,7 @@ class PolarizationPupilMapSettings:
 
 
 class PolarizationPupilMap(
-    BaseAnalysisWrapper[None, PolarizationPupilMapSettings],
+    BaseAnalysisWrapper[Union[PolarizationPupilMapResult, None], PolarizationPupilMapSettings],
     analysis_type="PolarizationPupilMap",
     needs_config_file=True,
     needs_text_output_file=True,

--- a/zospy/analyses/new/polarization/pupil_map.py
+++ b/zospy/analyses/new/polarization/pupil_map.py
@@ -84,13 +84,13 @@ class PolarizationPupilMapSettings:
     sub_configs: str = Field(default="", description="Subtract configurations")
 
 
-class PolarizationPupilMap(BaseAnalysisWrapper[None, PolarizationPupilMapSettings]):
+class PolarizationPupilMap(
+    BaseAnalysisWrapper[None, PolarizationPupilMapSettings],
+    analysis_type="PolarizationPupilMap",
+    needs_config_file=True,
+    needs_text_output_file=True,
+):
     """Polarization pupil map analysis."""
-
-    TYPE = "PolarizationPupilMap"
-
-    _needs_config_file = True
-    _needs_text_output_file = True
 
     def __init__(
         self,
@@ -105,7 +105,6 @@ class PolarizationPupilMap(BaseAnalysisWrapper[None, PolarizationPupilMapSetting
         sampling: str | int = "11x11",
         add_configs: str = "",
         sub_configs: str = "",
-        settings: PolarizationPupilMapSettings | None = None,
     ):
         """Create a new polarization pupil map analysis.
 
@@ -113,7 +112,7 @@ class PolarizationPupilMap(BaseAnalysisWrapper[None, PolarizationPupilMapSetting
         --------
         PolarizationPupilMapSettings : Settings for the polarization pupil map analysis.
         """
-        super().__init__(settings or PolarizationPupilMapSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> PolarizationPupilMapResult:
         """Run the polarization pupil map analysis."""

--- a/zospy/analyses/new/polarization/transmission.py
+++ b/zospy/analyses/new/polarization/transmission.py
@@ -92,13 +92,13 @@ class PolarizationTransmissionSettings:
     y_phase: float = Field(default=0, description="Jones electric field vector Y phase in degrees")
 
 
-class PolarizationTransmission(BaseAnalysisWrapper[PolarizationTransmissionResult, PolarizationTransmissionSettings]):
+class PolarizationTransmission(
+    BaseAnalysisWrapper[PolarizationTransmissionResult, PolarizationTransmissionSettings],
+    analysis_type="Transmission",
+    needs_config_file=True,
+    needs_text_output_file=True,
+):
     """Polarization transmission analysis."""
-
-    TYPE = "Transmission"
-
-    _needs_config_file = True
-    _needs_text_output_file = True
 
     def __init__(
         self,
@@ -109,7 +109,6 @@ class PolarizationTransmission(BaseAnalysisWrapper[PolarizationTransmissionResul
         jy: float = 0,
         x_phase: float = 0,
         y_phase: float = 0,
-        settings: PolarizationTransmissionSettings | None = None,
     ):
         """Create a new polarization transmission analysis.
 
@@ -117,7 +116,7 @@ class PolarizationTransmission(BaseAnalysisWrapper[PolarizationTransmissionResul
         --------
         PolarizationTransmissionSettings : Settings for the polarization transmission analysis.
         """
-        super().__init__(settings or PolarizationTransmissionSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> PolarizationTransmissionResult:
         """Run the polarization transmission analysis."""

--- a/zospy/analyses/new/psf/huygens_psf.py
+++ b/zospy/analyses/new/psf/huygens_psf.py
@@ -60,7 +60,7 @@ class HuygensPSFSettings:
     normalize: bool = Field(default=False, description="Normalize")
 
 
-class HuygensPSF(BaseAnalysisWrapper[DataFrame | None, HuygensPSFSettings]):
+class HuygensPSF(BaseAnalysisWrapper[DataFrame | None, HuygensPSFSettings], analysis_type="HuygensPsf"):
     """Huygens Point Spread Function (PSF) analysis."""
 
     def __init__(
@@ -77,7 +77,6 @@ class HuygensPSF(BaseAnalysisWrapper[DataFrame | None, HuygensPSFSettings]):
         use_polarization: bool = False,
         use_centroid: bool = False,
         normalize: bool = False,
-        settings: HuygensPSFSettings | None = None,
     ):
         """Create a new Huygens PSF analysis.
 
@@ -85,7 +84,7 @@ class HuygensPSF(BaseAnalysisWrapper[DataFrame | None, HuygensPSFSettings]):
         --------
         HuygensPSFSettings : Settings for the Huygens PSF analysis.
         """
-        super().__init__(settings or HuygensPSFSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> DataFrame | None:
         """Run the Huygens PSF analysis."""

--- a/zospy/analyses/new/psf/huygens_psf.py
+++ b/zospy/analyses/new/psf/huygens_psf.py
@@ -15,6 +15,7 @@ from zospy.utils.zputils import standardize_sampling
 
 __all__ = ("HuygensPSF", "HuygensPSFSettings")
 
+
 @analysis_settings
 class HuygensPSFSettings:
     """Settings for the Huygens PSF analysis.

--- a/zospy/analyses/new/psf/huygens_psf.py
+++ b/zospy/analyses/new/psf/huygens_psf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Union
 
 from pandas import DataFrame
 from pydantic import Field
@@ -13,6 +13,7 @@ from zospy.analyses.new.parsers.types import FieldNumber, WavelengthNumber  # no
 from zospy.api import constants
 from zospy.utils.zputils import standardize_sampling
 
+__all__ = ("HuygensPSF", "HuygensPSFSettings")
 
 @analysis_settings
 class HuygensPSFSettings:
@@ -60,7 +61,7 @@ class HuygensPSFSettings:
     normalize: bool = Field(default=False, description="Normalize")
 
 
-class HuygensPSF(BaseAnalysisWrapper[DataFrame | None, HuygensPSFSettings], analysis_type="HuygensPsf"):
+class HuygensPSF(BaseAnalysisWrapper[Union[DataFrame, None], HuygensPSFSettings], analysis_type="HuygensPsf"):
     """Huygens Point Spread Function (PSF) analysis."""
 
     def __init__(

--- a/zospy/analyses/new/raysandspots/ray_fan.py
+++ b/zospy/analyses/new/raysandspots/ray_fan.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 import numpy as np
 import pandas as pd

--- a/zospy/analyses/new/raysandspots/ray_fan.py
+++ b/zospy/analyses/new/raysandspots/ray_fan.py
@@ -124,10 +124,8 @@ class RayFanSettings:
     check_apertures: bool = Field(default=True, description="Only draw rays that pass all surface apertures")
 
 
-class RayFan(BaseAnalysisWrapper[Union[DataFrame, None], RayFanSettings]):
+class RayFan(BaseAnalysisWrapper[Union[DataFrame, None], RayFanSettings], analysis_type="RayFan"):
     """Ray Fan analysis."""
-
-    TYPE = "RayFan"
 
     def __init__(
         self,
@@ -142,7 +140,6 @@ class RayFan(BaseAnalysisWrapper[Union[DataFrame, None], RayFanSettings]):
         use_dashes: bool = False,
         vignetted_pupil: bool = True,
         check_apertures: bool = True,
-        settings: RayFanSettings | None = None,
     ):
         """Create a new Ray Fan analysis.
 
@@ -150,7 +147,7 @@ class RayFan(BaseAnalysisWrapper[Union[DataFrame, None], RayFanSettings]):
         --------
         RayFanSettings : Settings for the Ray Fan analysis.
         """
-        super().__init__(settings or RayFanSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> RayFanResult | None:
         """Run the Ray Fan analysis."""

--- a/zospy/analyses/new/raysandspots/ray_fan.py
+++ b/zospy/analyses/new/raysandspots/ray_fan.py
@@ -124,7 +124,7 @@ class RayFanSettings:
     check_apertures: bool = Field(default=True, description="Only draw rays that pass all surface apertures")
 
 
-class RayFan(BaseAnalysisWrapper[Union[DataFrame, None], RayFanSettings], analysis_type="RayFan"):
+class RayFan(BaseAnalysisWrapper[RayFanResult, RayFanSettings], analysis_type="RayFan"):
     """Ray Fan analysis."""
 
     def __init__(
@@ -149,7 +149,7 @@ class RayFan(BaseAnalysisWrapper[Union[DataFrame, None], RayFanSettings], analys
         """
         super().__init__(settings_kws=locals())
 
-    def run_analysis(self) -> RayFanResult | None:
+    def run_analysis(self) -> RayFanResult:
         """Run the Ray Fan analysis."""
         self.analysis.field = self.settings.field
         self.analysis.set_surface(self.settings.surface)

--- a/zospy/analyses/new/raysandspots/single_ray_trace.py
+++ b/zospy/analyses/new/raysandspots/single_ray_trace.py
@@ -101,12 +101,12 @@ class SingleRayTraceSettings:
     global_coordinates: bool = Field(default=False, description="Use global coordinates")
 
 
-class SingleRayTrace(BaseAnalysisWrapper[SingleRayTraceResult, SingleRayTraceSettings]):
+class SingleRayTrace(
+    BaseAnalysisWrapper[SingleRayTraceResult, SingleRayTraceSettings],
+    analysis_type="RayTrace",
+    needs_text_output_file=True,
+):
     """Single Ray Trace analysis."""
-
-    TYPE = "RayTrace"
-
-    _needs_text_output_file = True
 
     def __init__(
         self,
@@ -119,9 +119,14 @@ class SingleRayTrace(BaseAnalysisWrapper[SingleRayTraceResult, SingleRayTraceSet
         field: int = 1,
         raytrace_type: constants.Analysis.Settings.Aberrations.RayTraceType | str = "DirectionCosines",
         global_coordinates: bool = False,
-        settings: SingleRayTraceSettings | None = None,
     ):
-        super().__init__(settings or SingleRayTraceSettings(), locals())
+        """Create a new Single Ray Trace analysis.
+
+        See Also
+        --------
+        SingleRayTraceSettings : Settings for the Single Ray Trace analysis.
+        """
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> SingleRayTraceResult:
         """Run the Single Ray Trace analysis."""

--- a/zospy/analyses/new/raysandspots/single_ray_trace.py
+++ b/zospy/analyses/new/raysandspots/single_ray_trace.py
@@ -14,7 +14,7 @@ from zospy.analyses.new.parsers.transformers import ZospyTransformer
 from zospy.analyses.new.parsers.types import UnitField, ValidatedDataFrame  # noqa: TCH001
 from zospy.api import constants
 
-__all__ = ("SingleRayTrace", "SingleRayTraceSettings", "SingleRayTraceResult")
+__all__ = ("SingleRayTrace", "SingleRayTraceSettings")
 
 
 class SingleRayTraceTransformer(ZospyTransformer):

--- a/zospy/analyses/new/reports/cardinal_points.py
+++ b/zospy/analyses/new/reports/cardinal_points.py
@@ -95,12 +95,13 @@ class CardinalPointsSettings:
         return self
 
 
-class CardinalPoints(BaseAnalysisWrapper[CardinalPointsResult, CardinalPointsSettings]):
+class CardinalPoints(
+    BaseAnalysisWrapper[CardinalPointsResult, CardinalPointsSettings],
+    analysis_type="CardinalPoints",
+    needs_text_output_file=True,
+    needs_config_file=True,
+):
     """Cardinal points analysis."""
-
-    TYPE = "CardinalPoints"
-    _needs_text_output_file = True
-    _needs_config_file = True
 
     def __init__(
         self,
@@ -109,7 +110,6 @@ class CardinalPoints(BaseAnalysisWrapper[CardinalPointsResult, CardinalPointsSet
         surface_2: int | Literal["Image"] = "Image",
         wavelength: int = 1,
         orientation: Literal["Y-Z", "X-Z"] = "Y-Z",
-        settings: CardinalPointsSettings | None = None,
     ):
         """Create a new Cardinal Points analysis.
 
@@ -117,7 +117,7 @@ class CardinalPoints(BaseAnalysisWrapper[CardinalPointsResult, CardinalPointsSet
         --------
         CardinalPointsSettings : Settings for the Cardinal Points analysis.
         """
-        super().__init__(settings or CardinalPointsSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> CardinalPointsResult:
         """Run the Cardinal Points analysis."""

--- a/zospy/analyses/new/reports/surface_data.py
+++ b/zospy/analyses/new/reports/surface_data.py
@@ -10,7 +10,7 @@ from zospy.analyses.new.base import BaseAnalysisWrapper
 from zospy.analyses.new.decorators import analysis_result, analysis_settings
 from zospy.analyses.new.parsers.transformers import SimpleField, ZospyTransformer
 
-__all__ = ("SurfaceData", "SurfaceDataSettings", "SurfaceDataResult")
+__all__ = ("SurfaceData", "SurfaceDataSettings")
 
 
 class SurfaceDataTransformer(ZospyTransformer):

--- a/zospy/analyses/new/reports/surface_data.py
+++ b/zospy/analyses/new/reports/surface_data.py
@@ -97,16 +97,16 @@ class SurfaceDataSettings:
     surface: int = Field(default=1, ge=0, description="Surface number to analyze.")
 
 
-class SurfaceData(BaseAnalysisWrapper[SurfaceDataResult, SurfaceDataSettings]):
+class SurfaceData(
+    BaseAnalysisWrapper[SurfaceDataResult, SurfaceDataSettings],
+    analysis_type="SurfaceDataSettings",
+    needs_text_output_file=True,
+    needs_config_file=True,
+):
     """Surface Data analysis."""
 
-    TYPE = "SurfaceDataSettings"
-
-    _needs_config_file = True
-    _needs_text_output_file = True
-
-    def __init__(self, surface: int = 1, settings: SurfaceDataSettings | None = None):
-        super().__init__(settings or SurfaceDataSettings(), locals())
+    def __init__(self, surface: int = 1):
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> SurfaceDataResult:
         """Run the Surface Data analysis."""

--- a/zospy/analyses/new/reports/system_data.py
+++ b/zospy/analyses/new/reports/system_data.py
@@ -180,19 +180,15 @@ class SystemDataResult:
     abcd_matrix: ABCDMatrix = Field(alias="Predicted coordinate ABCD matrix")
 
 
-class SystemData(BaseAnalysisWrapper[SystemDataResult, None]):
+class SystemData(BaseAnalysisWrapper[SystemDataResult, None], analysis_type="SystemData", needs_text_output_file=True):
     """System Data analysis."""
-
-    TYPE = "SystemData"
-
-    _needs_text_output_file = True
 
     def __init__(self):
         """Create a new System Data analysis.
 
         This analysis does not require any settings.
         """
-        super().__init__(None, {})
+        super().__init__()
 
     def run_analysis(self) -> SystemDataResult:
         """Run the System Data analysis."""

--- a/zospy/analyses/new/surface/curvature.py
+++ b/zospy/analyses/new/surface/curvature.py
@@ -74,10 +74,8 @@ class CurvatureSettings:
     bfs_reverse_direction: bool = Field(default=False, description="Reverse BFS radius sign")
 
 
-class Curvature(BaseAnalysisWrapper[CurvatureResult, CurvatureSettings]):
+class Curvature(BaseAnalysisWrapper[CurvatureResult, CurvatureSettings], analysis_type="SurfaceCurvature"):
     """Surface Curvature analysis."""
-
-    TYPE = "SurfaceCurvature"
 
     def __init__(
         self,
@@ -91,7 +89,6 @@ class Curvature(BaseAnalysisWrapper[CurvatureResult, CurvatureSettings]):
         contour_format: str = "",
         bfs_criterion: str | constants.Analysis.BestFitSphereOptions = "MinimumVolume",
         bfs_reverse_direction: bool = False,
-        settings: CurvatureSettings | None = None,
     ):
         """Create a new Curvature analysis.
 
@@ -99,7 +96,7 @@ class Curvature(BaseAnalysisWrapper[CurvatureResult, CurvatureSettings]):
         --------
         CurvatureSettings : Settings for the Curvature analysis.
         """
-        super().__init__(settings or CurvatureSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> list[CurvatureResult] | None:
         """Run the Curvature analysis."""

--- a/zospy/analyses/new/systemviewers/base.py
+++ b/zospy/analyses/new/systemviewers/base.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import weakref
 from abc import ABC, abstractmethod
 from dataclasses import fields
-from types import NoneType
 from typing import TYPE_CHECKING, Annotated, Generic, Literal, Optional, get_args
 from warnings import warn
 
@@ -48,7 +47,7 @@ class SystemViewerWrapper(BaseAnalysisWrapper[Optional[np.ndarray], AnalysisSett
                 base = cls.__orig_bases__[0]
                 cls._settings_type: type[AnalysisSettings] = get_args(base)[0]
             else:
-                cls._settings_type = NoneType
+                cls._settings_type = type(None)  # TODO: Replace with NoneType when dropping support for Python 3.9
 
         super().__init_subclass__(**kwargs)
 

--- a/zospy/analyses/new/systemviewers/base.py
+++ b/zospy/analyses/new/systemviewers/base.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import weakref
 from abc import ABC, abstractmethod
 from dataclasses import fields
-from typing import TYPE_CHECKING, Annotated, Generic, Literal, get_args
+from typing import TYPE_CHECKING, Annotated, Generic, Literal, Optional, get_args
 from warnings import warn
 
 import numpy as np
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 __all__ = ("SystemViewerWrapper", "ImageSize")
 
 
-class SystemViewerWrapper(BaseAnalysisWrapper[np.ndarray | None, AnalysisSettings], ABC, Generic[AnalysisSettings]):
+class SystemViewerWrapper(BaseAnalysisWrapper[Optional[np.ndarray], AnalysisSettings], ABC, Generic[AnalysisSettings]):
     """Base class for SystemViewer analyses."""
 
     ALLOWED_IMAGE_EXTENSIONS: tuple[str, ...] = ("bmp", "jpeg", "png")

--- a/zospy/analyses/new/systemviewers/base.py
+++ b/zospy/analyses/new/systemviewers/base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import weakref
 from abc import ABC, abstractmethod
 from dataclasses import fields
+from types import NoneType
 from typing import TYPE_CHECKING, Annotated, Generic, Literal, Optional, get_args
 from warnings import warn
 
@@ -47,7 +48,7 @@ class SystemViewerWrapper(BaseAnalysisWrapper[Optional[np.ndarray], AnalysisSett
                 base = cls.__orig_bases__[0]
                 cls._settings_type: type[AnalysisSettings] = get_args(base)[0]
             else:
-                cls._settings_type = None
+                cls._settings_type = NoneType
 
         super().__init_subclass__(**kwargs)
 

--- a/zospy/analyses/new/systemviewers/cross_section.py
+++ b/zospy/analyses/new/systemviewers/cross_section.py
@@ -79,11 +79,8 @@ class CrossSectionSettings:
     )
 
 
-class CrossSection(SystemViewerWrapper[CrossSectionSettings]):
+class CrossSection(SystemViewerWrapper[CrossSectionSettings], analysis_type="Draw2D", mode="Sequential"):
     """Cross section viewer."""
-
-    TYPE = "Draw2D"
-    MODE = "Sequential"
 
     def __init__(
         self,
@@ -103,7 +100,6 @@ class CrossSection(SystemViewerWrapper[CrossSectionSettings]):
         image_size: tuple[int, int] = (800, 600),
         rays_line_thickness: constants.Tools.Layouts.LineThicknessOptions | str = "Standard",
         surface_line_thickness: constants.Tools.Layouts.LineThicknessOptions | str = "Standard",
-        settings: CrossSectionSettings | None = None,
     ):
         """Create a new cross section viewer.
 
@@ -111,7 +107,7 @@ class CrossSection(SystemViewerWrapper[CrossSectionSettings]):
         --------
         CrossSectionSettings : Settings for the cross section viewer.
         """
-        super().__init__(settings or CrossSectionSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def configure_layout_tool(self) -> _ZOSAPI.Tools.Layouts.ICrossSectionExport:
         """Configure the cross section viewer."""

--- a/zospy/analyses/new/systemviewers/nsc_3d_layout.py
+++ b/zospy/analyses/new/systemviewers/nsc_3d_layout.py
@@ -12,6 +12,7 @@ from zospy.analyses.new.systemviewers.base import ImageSize, SystemViewerWrapper
 if TYPE_CHECKING:
     from zospy.api import _ZOSAPI
 
+__all__ = ("NSC3DLayout", "NSC3DLayoutSettings")
 
 @analysis_settings
 class NSC3DLayoutSettings:

--- a/zospy/analyses/new/systemviewers/nsc_3d_layout.py
+++ b/zospy/analyses/new/systemviewers/nsc_3d_layout.py
@@ -25,20 +25,17 @@ class NSC3DLayoutSettings:
     image_size: ImageSize = Field(default=(800, 600), description="Image size")
 
 
-class NSC3DLayout(SystemViewerWrapper[NSC3DLayoutSettings]):
+class NSC3DLayout(SystemViewerWrapper[NSC3DLayoutSettings], analysis_type="NSC3DLayout", mode="Nonsequential"):
     """3D Layout viewer for Non-Sequential systems."""
 
-    TYPE = "NSC3DLayout"
-    MODE = "Nonsequential"
-
-    def __init__(self, *, image_size: tuple[int, int] = (800, 600), settings: NSC3DLayoutSettings | None = None):
+    def __init__(self, *, image_size: tuple[int, int] = (800, 600)):
         """Create a new nonsequential 3D Layout viewer.
 
         See Also
         --------
         NSC3DLayoutSettings : Settings for the NSC 3D Layout viewer
         """
-        super().__init__(settings or NSC3DLayoutSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def configure_layout_tool(
         self,

--- a/zospy/analyses/new/systemviewers/nsc_3d_layout.py
+++ b/zospy/analyses/new/systemviewers/nsc_3d_layout.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 __all__ = ("NSC3DLayout", "NSC3DLayoutSettings")
 
+
 @analysis_settings
 class NSC3DLayoutSettings:
     """Settings for the nonsequential 3D Layout viewer.

--- a/zospy/analyses/new/systemviewers/nsc_shaded_model.py
+++ b/zospy/analyses/new/systemviewers/nsc_shaded_model.py
@@ -12,6 +12,8 @@ from zospy.analyses.new.systemviewers.base import ImageSize, SystemViewerWrapper
 if TYPE_CHECKING:
     from zospy.api import _ZOSAPI
 
+__all__ = ("NSCShadedModel", "NSCShadedModelSettings")
+
 
 @analysis_settings
 class NSCShadedModelSettings:

--- a/zospy/analyses/new/systemviewers/nsc_shaded_model.py
+++ b/zospy/analyses/new/systemviewers/nsc_shaded_model.py
@@ -25,20 +25,17 @@ class NSCShadedModelSettings:
     image_size: ImageSize = Field(default=(800, 600), description="Image size")
 
 
-class NSCShadedModel(SystemViewerWrapper[NSCShadedModelSettings]):
+class NSCShadedModel(SystemViewerWrapper[NSCShadedModelSettings], analysis_type="NSCShadedModel", mode="Nonsequential"):
     """Nonsequential Shaded Model viewer."""
 
-    TYPE = "NSCShadedModel"
-    MODE = "Nonsequential"
-
-    def __init__(self, *, image_size: ImageSize = (800, 600), settings: NSCShadedModelSettings | None = None):
+    def __init__(self, *, image_size: ImageSize = (800, 600)):
         """Create a new nonsequential shaded model viewer.
 
         See Also
         --------
         NSCShadedModelSettings : Settings for the nonsequential shaded model viewer.
         """
-        super().__init__(settings or NSCShadedModelSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def configure_layout_tool(self) -> _ZOSAPI.Tools.Layouts.IShadedModelExport:
         """Configure the nonsequential shaded model viewer."""

--- a/zospy/analyses/new/systemviewers/shaded_model.py
+++ b/zospy/analyses/new/systemviewers/shaded_model.py
@@ -27,20 +27,17 @@ class ShadedModelSettings:
     image_size: ImageSize = Field(default=(800, 600), description="Image size")
 
 
-class ShadedModel(SystemViewerWrapper[ShadedModelSettings]):
+class ShadedModel(SystemViewerWrapper[ShadedModelSettings], analysis_type="ShadedModel", mode="Sequential"):
     """Shaded Model viewer."""
 
-    TYPE = "ShadedModel"
-    MODE = "Sequential"
-
-    def __init__(self, *, image_size: tuple[int, int] = (800, 600), settings: ShadedModelSettings | None = None):
+    def __init__(self, *, image_size: tuple[int, int] = (800, 600)):
         """Initialize the Shaded Model viewer.
 
         See Also
         --------
         ShadedModelSettings : Settings for the Shaded Model viewer.
         """
-        super().__init__(settings or ShadedModelSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def configure_layout_tool(
         self,

--- a/zospy/analyses/new/systemviewers/viewer_3d.py
+++ b/zospy/analyses/new/systemviewers/viewer_3d.py
@@ -133,11 +133,8 @@ class Viewer3DSettings:
     image_size: ImageSize = Field(default=(800, 600), description="Image size")
 
 
-class Viewer3D(SystemViewerWrapper[Viewer3DSettings]):
+class Viewer3D(SystemViewerWrapper[Viewer3DSettings], analysis_type="Draw3D", mode="Sequential"):
     """3D system viewer."""
-
-    TYPE = "Draw3D"
-    MODE = "Sequential"
 
     def __init__(
         self,
@@ -170,7 +167,6 @@ class Viewer3D(SystemViewerWrapper[Viewer3DSettings]):
         camera_viewpoint_angle_y: float = 0,
         camera_viewpoint_angle_z: float = 0,
         image_size: tuple[int, int] = (800, 600),
-        settings: Viewer3DSettings | None = None,
     ):
         """Create a new 3D system viewer.
 
@@ -178,7 +174,7 @@ class Viewer3D(SystemViewerWrapper[Viewer3DSettings]):
         --------
         Viewer3DSettings : Settings for the 3D system viewer.
         """
-        super().__init__(settings or Viewer3DSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def configure_layout_tool(
         self,

--- a/zospy/analyses/new/wavefront/wavefront_map.py
+++ b/zospy/analyses/new/wavefront/wavefront_map.py
@@ -75,13 +75,8 @@ class WavefrontMapSettings:
     contour_format: str = Field(default="", description="Contour format")
 
 
-class WavefrontMap(BaseAnalysisWrapper[DataFrame, WavefrontMapSettings]):
+class WavefrontMap(BaseAnalysisWrapper[DataFrame, WavefrontMapSettings], analysis_type="WavefrontMap"):
     """Wavefront Map analysis."""
-
-    TYPE = "WavefrontMap"
-
-    _needs_config_file = False
-    _needs_text_output_file = False
 
     def __init__(
         self,
@@ -101,9 +96,8 @@ class WavefrontMap(BaseAnalysisWrapper[DataFrame, WavefrontMapSettings]):
         sub_aperture_y: float = 0.0,
         sub_aperture_r: float = 1.0,
         contour_format: str = "",
-        settings: WavefrontMapSettings | None = None,
     ):
-        super().__init__(settings or WavefrontMapSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> DataFrame:
         """Run the Wavefront Map analysis.

--- a/zospy/analyses/new/wavefront/wavefront_map.py
+++ b/zospy/analyses/new/wavefront/wavefront_map.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Union
 
 from pandas import DataFrame
 from pydantic import Field
@@ -12,6 +12,8 @@ from zospy.analyses.new.decorators import analysis_settings
 from zospy.analyses.new.parsers.types import ZOSAPIConstant  # noqa: TCH001
 from zospy.api import constants
 from zospy.utils.zputils import standardize_sampling
+
+__all__ = ("WavefrontMap", "WavefrontMapSettings")
 
 
 @analysis_settings
@@ -75,7 +77,7 @@ class WavefrontMapSettings:
     contour_format: str = Field(default="", description="Contour format")
 
 
-class WavefrontMap(BaseAnalysisWrapper[DataFrame, WavefrontMapSettings], analysis_type="WavefrontMap"):
+class WavefrontMap(BaseAnalysisWrapper[Union[DataFrame, None], WavefrontMapSettings], analysis_type="WavefrontMap"):
     """Wavefront Map analysis."""
 
     def __init__(

--- a/zospy/analyses/new/wavefront/zernike_standard_coefficients.py
+++ b/zospy/analyses/new/wavefront/zernike_standard_coefficients.py
@@ -14,7 +14,7 @@ from zospy.analyses.new.parsers.types import UnitField  # noqa: TCH001
 from zospy.api import constants
 from zospy.utils.zputils import standardize_sampling
 
-__all__ = ("ZernikeStandardCoefficients", "ZernikeStandardCoefficientsSettings", "ZernikeStandardCoefficientsResult")
+__all__ = ("ZernikeStandardCoefficients", "ZernikeStandardCoefficientsSettings")
 
 
 class ZernikeStandardCoefficientsTransformer(ZospyTransformer):

--- a/zospy/analyses/new/wavefront/zernike_standard_coefficients.py
+++ b/zospy/analyses/new/wavefront/zernike_standard_coefficients.py
@@ -89,13 +89,11 @@ class ZernikeStandardCoefficientsSettings:
 
 
 class ZernikeStandardCoefficients(
-    BaseAnalysisWrapper[ZernikeStandardCoefficientsResult, ZernikeStandardCoefficientsSettings]
+    BaseAnalysisWrapper[ZernikeStandardCoefficientsResult, ZernikeStandardCoefficientsSettings],
+    analysis_type="ZernikeStandardCoefficients",
+    needs_text_output_file=True,
 ):
     """Zernike Standard Coefficients analysis."""
-
-    TYPE = "ZernikeStandardCoefficients"
-
-    _needs_text_output_file = True
 
     def __init__(
         self,
@@ -109,9 +107,8 @@ class ZernikeStandardCoefficients(
         sx: float = 0.0,
         sy: float = 0.0,
         sr: float = 0.0,
-        settings: ZernikeStandardCoefficientsSettings | None = None,
     ):
-        super().__init__(settings or ZernikeStandardCoefficientsSettings(), locals())
+        super().__init__(settings_kws=locals())
 
     def run_analysis(self) -> ZernikeStandardCoefficientsResult:
         """Run the Zernike Standard Coefficients analysis."""


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

This is a follow-up on #108.

In the current implementation, analysis settings can be specified using both a settings object and keyword arguments.
In some cases, this implementation can prevent changing modified settings back to their default values.
Implementations that don't exhibit this behavior rely on `**kwargs`, which means we lose the specification of the default arguments in the function signature.

The `__init__` method of analysis wrappers now only allows to specify the settings using keyword arguments. Initializing an analysis with a settings object can be done using the `from_settings` classmethod, e.g. `ZernikeStandardCoefficients.from_settings(ZernikeStandardCoefficientsSettings(sampling="64x64", maximum_term=45))`. **A downside of this implementation is that we lose the ability to create a new 'default' set of settings and then easily overwrite some of these settings**, which was a major reason to choose the previously proposed implementation, but we can probably live with that.

Other (related) changes:

- The type of the analysis settings object is now determined from the class signature, e.g. `class PolarizationTransmission(
    BaseAnalysisWrapper[PolarizationTransmissionResult, PolarizationTransmissionSettings]): ...` is sufficient to let `BaseAnalysisWrapper` find out that settings should have the `PolarizationTransmissionSettings` type. As a result, it is no longer necessary to create a `PolarizationTransmissionSettings` instance in `PolarizationTransmission.__init__`.
- All analysis classes contained some configuration parameters (e.g. the analysis type) that were specified as class attributes. These are now specified as arguments instead. See the example below:

```python
# Old specification
class PolarizationTransmission(
    BaseAnalysisWrapper[PolarizationTransmissionResult, PolarizationTransmissionSettings],
):
    TYPE = "Transmission"
    _needs_config_file = True
    _needs_text_output_file = True

    ...

# New specification
class PolarizationTransmission(
    BaseAnalysisWrapper[PolarizationTransmissionResult, PolarizationTransmissionSettings],
    analysis_type="Transmission",
    needs_config_file=True,
    needs_text_output_file=True,
):
    ...
```

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.9-3.12
- OpticStudio version: 24R2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
