### PR TITLE
Fix start_surface assigment in physical_optics_propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 # Editor settings
 .idea/
 .vscode/
+.vs/
 
 # Temporary data files
 scripts/**/*.pickle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ ZOS-API can also be added in patch releases.
 
 ### Removed
 
+## [[1.3.1]](https://github.com/MREYE-LUMC/ZOSPy/releases/tag/v1.3.1) - 2025-01-16
+
+### Fixed
+
+- Physical optics analysis start surface was hardcoded to 1 (#111, #112)
+
 ## [[1.3.0]](https://github.com/MREYE-LUMC/ZOSPy/releases/tag/v1.3.0) - 2024-10-30
 
 ### Added

--- a/zospy/analyses/physicaloptics.py
+++ b/zospy/analyses/physicaloptics.py
@@ -332,7 +332,7 @@ def physical_optics_propagation(
     if start_surface == "Ent. Pupil":
         analysis.Settings.StartSurface.SetSurfaceNumber(0)
     elif isinstance(start_surface, int):
-        analysis.Settings.StartSurface.SetSurfaceNumber(1)
+        analysis.Settings.StartSurface.SetSurfaceNumber(start_surface)
     else:
         raise ValueError(f'start_surface value should be "Ent. Pupil" or an integer, got {start_surface}')
 


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

I fixe the incorrect assignment of start_surface in physical_optics_propagation. The line now uses the start_surface variable instead of a hardcoded 1

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.10, 3.8
- OpticStudio version: 2024 R2.01

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

Typo in the physical_optics_propagation function #111

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [ ] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [x] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
