### PR TITLE
Fixed setting beam and fiber type with external files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ ZOS-API can also be added in patch releases.
 
 ### Fixed
 
+- Setting beam and fiber type with external files in PhysicalOpticsPropagation (#105)
+
 ### Changed
 
 ### Deprecated

--- a/zospy/analyses/physicaloptics.py
+++ b/zospy/analyses/physicaloptics.py
@@ -378,7 +378,7 @@ def physical_optics_propagation(
 
     if beam_file != "":
         if str(analysis.Settings.BeamType) in ("File", "DLL", "Multimode"):
-            analysis.Settings.BeamFile = beam_file
+            analysis.Settings.BeamTypeFilename = beam_file
         else:
             raise ValueError(f"Beam type {str(beam_type)} does not allow specification of beam_file.")
 
@@ -431,7 +431,7 @@ def physical_optics_propagation(
 
         if fiber_type_file != "":
             if str(analysis.Settings.FiberType) in ("File", "DLL"):
-                analysis.Settings.FiberTypeFile = fiber_type_file
+                analysis.Settings.FiberTypeFilename = fiber_type_file
             else:
                 raise ValueError(
                     f"Beam type {str(analysis.Settings.FiberType)} does not allow specification of fiber_type_file."
@@ -483,7 +483,7 @@ def physical_optics_propagation(
         settings.loc["PeakIrradiance"] = analysis.Settings.PeakIrradiance
 
     if str(analysis.Settings.BeamType) in ("File", "DLL", "Multimode"):
-        settings.loc["BeamFile"] = analysis.Settings.BeamFile
+        settings.loc["BeamTypeFilename"] = analysis.Settings.BeamTypeFilename
 
     for i in range(analysis.Settings.NumberOfParameters):
         key = "Beam" + "".join(analysis.Settings.GetParameterName(i).split(" "))
@@ -522,7 +522,7 @@ def physical_optics_propagation(
         settings.loc["TiltAboutY"] = analysis.Settings.TiltAboutY
 
         if str(analysis.Settings.FiberType) in ("File", "DLL"):
-            settings.loc["FiberTypeFile"] = analysis.Settings.FiberTypeFile
+            settings.loc["FiberTypeFilename"] = analysis.Settings.FiberTypeFilename
 
         for i in range(analysis.Settings.NumberOfFiberParameters):
             key = "Fiber" + "".join(analysis.Settings.GetFiberParameterName(i).split(" "))


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->
As mentioned in https://github.com/MREYE-LUMC/ZOSPy/pull/105, there was a bug in setting the beam or fiber type with an external file (DLL, etc.), as an incorrect `Settings` attribute was set. This PR fixes that.


## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.11
- OpticStudio version: 20.3.2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
