### PR TITLE
Implemented skip for Tools.Layouts in test_constant_exists with older OpticStudio versions

### DIFF
--- a/tests/analyses/new/parsers/test_types.py
+++ b/tests/analyses/new/parsers/test_types.py
@@ -7,7 +7,6 @@ from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from pydantic import TypeAdapter, ValidationError
 
-from tests.conftest import optic_studio_version
 from zospy.analyses.new.parsers.types import ValidatedDataFrame, ValidatedNDArray, ZOSAPIConstantAnnotation
 from zospy.api import constants
 

--- a/tests/analyses/new/parsers/test_types.py
+++ b/tests/analyses/new/parsers/test_types.py
@@ -7,6 +7,7 @@ from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from pydantic import TypeAdapter, ValidationError
 
+from tests.conftest import optic_studio_version
 from zospy.analyses.new.parsers.types import ValidatedDataFrame, ValidatedNDArray, ZOSAPIConstantAnnotation
 from zospy.api import constants
 
@@ -98,5 +99,7 @@ class TestZOSAPIConstant:
         return True
 
     @pytest.mark.parametrize("annotation", _get_instances())
-    def test_constant_exists(self, zos, annotation):  # noqa: ARG002
+    def test_constant_exists(self, zos, annotation, optic_studio_version):  # noqa: ARG002
+        if annotation.enum.startswith("Tools.Layouts") and optic_studio_version < "24.1.0":
+            pytest.skip(f"{annotation.enum} is only available from OpticStudio 24.1 onwards")
         assert self._hasattr(constants, annotation.enum)

--- a/tests/analyses/new/parsers/test_types.py
+++ b/tests/analyses/new/parsers/test_types.py
@@ -1,5 +1,6 @@
 import gc
 import json
+from typing import ClassVar
 
 import numpy as np
 import pytest
@@ -87,6 +88,12 @@ def _get_zosapi_constant_instances():
 
 
 class TestZOSAPIConstant:
+    CONSTANT_MINIMUM_ZOS_VERSIONS: ClassVar[dict] = {
+        "Tools": {
+            "Layouts": "24.1.0",
+        }
+    }
+
     @staticmethod
     def _hasattr(obj, attr):
         for name in attr.split("."):
@@ -97,8 +104,22 @@ class TestZOSAPIConstant:
 
         return True
 
+    def _constant_exists_in_version(self, constant: str, version) -> bool:
+        _minimum_zos_version = self.CONSTANT_MINIMUM_ZOS_VERSIONS
+
+        for namespace in constant.split("."):
+            _minimum_zos_version = _minimum_zos_version.get(namespace)
+
+            if _minimum_zos_version is None:
+                return True
+            if isinstance(_minimum_zos_version, str):
+                return version >= _minimum_zos_version
+
+        return True
+
     @pytest.mark.parametrize("annotation", _get_zosapi_constant_instances())
     def test_constant_exists(self, zos, annotation, optic_studio_version):  # noqa: ARG002
-        if annotation.enum.startswith("Tools.Layouts") and optic_studio_version < "24.1.0":
-            pytest.skip(f"{annotation.enum} is only available from OpticStudio 24.1 onwards")
+        if not self._constant_exists_in_version(annotation.enum, optic_studio_version):
+            pytest.skip(f"{annotation.enum} is not available in OpticStudio {optic_studio_version}")
+
         assert self._hasattr(constants, annotation.enum)


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->
`test_constant_exists` currently tests all constants, including constants under `Tools.Layouts`. This fails on OpticStudio versions < 24R1 as `Tools.Layouts` did not exist yet. I think it is optimal to implement the skip within the tests in this instance, as the tested constants are outomatically determined.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.11
- OpticStudio version: 20.3.2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
