### PR TITLE
Added method to convert Zernike standard coefficients to dataframe

### DIFF
--- a/zospy/analyses/new/wavefront/zernike_standard_coefficients.py
+++ b/zospy/analyses/new/wavefront/zernike_standard_coefficients.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+import pandas as pd
 from pydantic import Field
 
 from zospy.analyses.new.base import BaseAnalysisWrapper
@@ -71,6 +72,11 @@ class ZernikeStandardCoefficientsResult:
     maximum_fit_error: UnitField = Field(alias="Maximum fit error")
 
     coefficients: dict[int, ZernikeStandardCoefficient] = Field(alias="Coefficients")
+
+    def coefficients_as_dataframe(self):
+        df = pd.DataFrame(self.coefficients.values(), index=self.coefficients.keys())
+        df.index.name = "Coefficient"
+        return df
 
 
 @analysis_settings


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->
I added a  method to quickly obtain the coefficients from `ZernikeStandardCoefficientResult` to a pandas `DataFrame`. As `ZernikeStandardCoefficientResult.coefficients` is a dictionary and embedding that in a Pydantic `RootModel` while maintaining full dictionary functionality is not straightforward, it is added as property to `ZernikeStandardCoefficientResult`: `ZernikeStandardCoefficientResult.coefficients_dataframe`.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [x] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.11
- OpticStudio version: 20.3.2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using tox.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an analysis:

- [ ] I did not use `AttrDict`s for the analysis result data (please use dataclasses instead).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
