### PR TITLE
Make specifying the OpticStudioSystem for analyses optional

### DIFF
--- a/zospy/analyses/base.py
+++ b/zospy/analyses/base.py
@@ -56,6 +56,7 @@ from zospy.analyses.parsers.types import ValidatedDataFrame
 from zospy.api import _ZOSAPI, constants
 from zospy.utils import zputils
 from zospy.utils.clrutils import system_datetime_to_datetime
+from zospy.utils.zputils import get_primary_system
 
 if TYPE_CHECKING:
     import sys
@@ -63,7 +64,7 @@ if TYPE_CHECKING:
     from lark import Transformer
     from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
-    from zospy.zpcore import OpticStudioSystem
+    from zospy.zpcore import OpticStudioSystem, ZOS
 
     if sys.version_info <= (3, 11):
         from typing_extensions import NotRequired
@@ -812,8 +813,9 @@ class BaseAnalysisWrapper(ABC, Generic[AnalysisData, AnalysisSettings]):
 
         Parameters
         ----------
-        oss : OpticStudioSystem
-            The OpticStudio system.
+        oss : OpticStudioSystem | None
+            The OpticStudio system. If the OpticStudio system is not provided, ZOSPy will attempt to use the primary
+            system. If no primary system is found, an error will be raised.
         config_file : str | Path | None
             Path to the configuration file. If `None`, a temporary file will be created.
         text_output_file : str | Path | None
@@ -826,8 +828,13 @@ class BaseAnalysisWrapper(ABC, Generic[AnalysisData, AnalysisSettings]):
         -------
         AnalysisResult
             The analysis results.
+
+        Raises
+        ------
+        ValueError
+            If `oss` is not provided and the connection to OpticStudio has not been established.
         """
-        self._oss = weakref.proxy(oss)
+        self._oss = weakref.proxy(oss) if oss is not None else weakref.proxy(get_primary_system())
         self._check_mode()
         self._create_analysis()
 

--- a/zospy/utils/zputils.py
+++ b/zospy/utils/zputils.py
@@ -9,8 +9,10 @@ from typing import TypeVar
 import numpy as np
 import pandas as pd
 
+from zospy import ZOS
 from zospy.api import _ZOSAPI
 from zospy.api import config as _config
+from zospy.zpcore import OpticStudioSystem
 
 
 def flatten_dict(unflattened_dict, parent_key="", sep=".", *, keep_unflattened=False):
@@ -154,3 +156,26 @@ def _get_number_field(name: str, text: str) -> str:
         rf"{re.escape(name)}\s*:\s*([-+]?(\d+({re.escape(_config.DECIMAL_POINT)}\d*)?|{re.escape(_config.DECIMAL_POINT)}\d+)(?:[Ee][-+]?\d+)?)",
         text,
     ).group(1)
+
+
+def get_primary_system() -> OpticStudioSystem:
+    """Get the primary system from OpticStudio.
+
+    Checks if a connection to OpticStudio has been established and returns the primary system.
+
+    Returns
+    -------
+    OpticStudioSystem
+        The primary system in OpticStudio.
+
+    Raises
+    ------
+    ValueError
+        If a connection to OpticStudio has not been established.
+    """
+    zos = ZOS.get_instance()
+
+    if zos is None or zos.Application is None:
+        raise ValueError("Could not obtain the primary system. Please connect to OpticStudio first.")
+
+    return zos.get_primary_system()


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

`zospy.zpcore.ZOS` is now a singleton and allows to obtain the current `ZOS` instance. This means it is possible to obtain an optical system from within a function, without having to pass the system to that function.
Using this functionality, the `oss` parameter of `BaseAnalysisWrapper.run` can be made optional. If the OpticStudioSystem is not provided, the primary system can be automatically obtained. I implemented a utility function `get_primary_system` that tries to get the primary system and modified `BaseAnalysisWrapper.run` to use this when the `oss` argument is omitted.

I am not sure if this is actually a useful (it might have been more useful with the old, procedural interface for analyses). If you think this is useful, I will add unit tests and finalize this PR.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [x] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.9-3.12
- OpticStudio version: 24R1

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [ ] The code has been linted, formatted and tested locally using hatch.
- [ ] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
