### PR TITLE
Prevent a second initialization of ZOS

### DIFF
--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -53,6 +53,16 @@ def test_zos_singleton(zos, oss):
         assert zos2 is zos
 
 
+@pytest.mark.filterwarnings("ignore:Only a single instance of ZOS can exist at any time")
+def test_zos_singleton_logs(zos, caplog):
+    with caplog.at_level("DEBUG"):
+        zos2 = zp.ZOS()
+
+    assert "ZOS instance already initialized" in caplog.text
+    assert "Initializing ZOS instance" not in caplog.text
+    assert zos2 is zos
+
+
 def test_zos_get_instance(zos):
     assert zp.ZOS.get_instance() is zos
 

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -42,7 +42,7 @@ def test_load_zos_dlls_with_nethelper_and_opticstudio_directory_raises_valueerro
 
 
 @pytest.mark.must_pass  # Other tests will fail if this one does
-def test_zos_singleton(zos, oss):
+def test_zos_singleton(zos, oss):  # noqa: ARG001
     assert zos.Application is not None
 
     with pytest.warns(match=r"Only a single instance of ZOS can exist at any time\. Returning existing instance\."):

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -41,9 +41,15 @@ def test_load_zos_dlls_with_nethelper_and_opticstudio_directory_raises_valueerro
         zos._load_zos_dlls(zosapi_nethelper="dummy/path", opticstudio_directory="dummy/path")
 
 
-def test_init_second_zos_instance(zos):
+@pytest.mark.must_pass  # Other tests will fail if this one does
+def test_zos_singleton(zos, oss):
+    assert zos.Application is not None
+
     with pytest.warns(match=r"Only a single instance of ZOS can exist at any time\. Returning existing instance\."):
         zos2 = zp.ZOS()
+
+        # If init is called again, the Application attribute will be set to None
+        assert zos2.Application is not None
         assert zos2 is zos
 
 

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -397,6 +397,7 @@ class ZOS:
         """
         if cls not in cls._instances:
             instance = super().__new__(cls)
+            instance.__initialized = False
             cls._instances[cls] = instance
         else:
             warnings.warn("Only a single instance of ZOS can exist at any time. Returning existing instance.")
@@ -423,6 +424,10 @@ class ZOS:
             zosapi_nethelper. Note that either the zosapi_nethelper or the opticstudio_directory has to be specified,
             not both.
         """
+        if self.__initialized:
+            logger.debug("ZOS instance already initialized")
+            return
+
         logger.debug("Initializing ZOS instance")
 
         self.ZOSAPI: _ZOSAPI = None
@@ -436,6 +441,8 @@ class ZOS:
         logger.info("ZOS instance initialized")
 
         self._wakeup(preload=preload, zosapi_nethelper=zosapi_nethelper, opticstudio_directory=opticstudio_directory)
+
+        self.__initialized = True
 
     def _wakeup(
         self, *, preload: bool = False, zosapi_nethelper: str | None = None, opticstudio_directory: str | None = None

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -397,7 +397,7 @@ class ZOS:
         """
         if cls not in cls._instances:
             instance = super().__new__(cls)
-            instance.__initialized = False
+            instance.__initialized = False  # noqa: SLF001
             cls._instances[cls] = instance
         else:
             warnings.warn("Only a single instance of ZOS can exist at any time. Returning existing instance.")


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

`ZOS` is a singleton, meaning it can only be instantiated once. If a second instance is created, `ZOS.__new__` returns the existing instance. However, `__init__` is still called a second time on this already initialized `ZOS` instance. This causes some attributes, for example the connection to OpticStudio, to be reset to `None`. Unfortunately, this does not immediately break existing `OpticStudioSystem` instances, which is probably why we didn't notice this earlier.

I solved this by adding a new `__initialized` attribute, that is set to `True` when the `ZOS` instance is initialized. Initialization is skipped when this attribute is `True`.

This problem does not occur when using the decorator singleton pattern (see https://stackoverflow.com/questions/6760685/what-is-the-best-way-of-implementing-singleton-in-python). However, the decorator pattern breaks classmethods, and `ZOS` contains classmethods, so the current solution is probably the best we can achieve.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.12
- OpticStudio version: N/A

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using hatch.
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
