### PR TITLE
Keep old datagid label behaviour for analysis.old

### DIFF
--- a/zospy/analyses/old/extendedscene.py
+++ b/zospy/analyses/old/extendedscene.py
@@ -205,7 +205,9 @@ def geometric_image_analysis(
     # Get data and unpack
     data = []
     for ii in range(analysis.Results.NumberOfDataGrids):
-        data.append(utils.zputils.unpack_datagrid(analysis.Results.DataGrids[ii]))
+        data.append(utils.zputils.unpack_datagrid(analysis.Results.DataGrids[ii],
+                                                  # pass "center" and None for consistency with older ZOSPy versions
+                                                  cell_origin="center", label_rounding=None))
 
     if len(data) == 0:
         data = pd.DataFrame()

--- a/zospy/analyses/old/physicaloptics.py
+++ b/zospy/analyses/old/physicaloptics.py
@@ -532,7 +532,9 @@ def physical_optics_propagation(
     # Get data and unpack
     data = []
     for i in range(analysis.Results.NumberOfDataGrids):
-        data.append(utils.zputils.unpack_datagrid(analysis.Results.DataGrids[i]))
+        data.append(utils.zputils.unpack_datagrid(analysis.Results.DataGrids[i],
+                                                  # pass "center" and None for consistency with older ZOSPy versions
+                                                  cell_origin="center", label_rounding=None))
 
     if len(data) == 0:
         data = pd.DataFrame()

--- a/zospy/analyses/old/psf.py
+++ b/zospy/analyses/old/psf.py
@@ -116,13 +116,17 @@ def huygens_psf(
     if analysis.Results.NumberOfDataGrids <= 0:
         data = None
     elif analysis.Results.NumberOfDataGrids == 1:
-        data = utils.zputils.unpack_datagrid(analysis.Results.DataGrids[0])
+        data = utils.zputils.unpack_datagrid(analysis.Results.DataGrids[0],
+                                             # pass "center" and None for consistency with older ZOSPy versions
+                                             cell_origin="center", label_rounding=None)
     else:
         data = AttrDict()
         for ii in range(analysis.Results.NumberOfDataGrids):
             desc = analysis.Results.DataGrids[ii].Description
             key = desc if desc != "" else str(ii)
-            data[key] = utils.zputils.unpack_datagrid(analysis.Results.DataGrids[ii])
+            data[key] = utils.zputils.unpack_datagrid(analysis.Results.DataGrids[ii],
+                                                      # pass "center" and None for consistency with older ZOSPy versions
+                                                      cell_origin="center", label_rounding=None)
 
     result = AnalysisResult(
         analysistype=str(analysistype),

--- a/zospy/analyses/old/surface.py
+++ b/zospy/analyses/old/surface.py
@@ -127,13 +127,17 @@ def curvature(
     if analysis.Results.NumberOfDataGrids <= 0:
         data = None
     elif analysis.Results.NumberOfDataGrids == 1:
-        data = zputils.unpack_datagrid(analysis.Results.DataGrids[0])
+        data = zputils.unpack_datagrid(analysis.Results.DataGrids[0],
+                                       # pass "center" and None for consistency with older ZOSPy versions
+                                       cell_origin="center", label_rounding=None)
     else:
         data = AttrDict()
         for ii in range(analysis.Results.NumberOfDataGrids):
             desc = analysis.Results.DataGrids[ii].Description
             key = desc if desc != "" else str(ii)
-            data[key] = zputils.unpack_datagrid(analysis.Results.DataGrids[ii])
+            data[key] = zputils.unpack_datagrid(analysis.Results.DataGrids[ii],
+                                                # pass "center" and None for consistency with older ZOSPy versions
+                                                cell_origin="center", label_rounding=None)
 
     result = AnalysisResult(
         analysistype=str(analysis_type),

--- a/zospy/analyses/old/wavefront.py
+++ b/zospy/analyses/old/wavefront.py
@@ -142,7 +142,9 @@ def wavefront_map(
 
     data = []
     for ii in range(analysis.Results.NumberOfDataGrids):
-        data.append(unpack_datagrid(analysis.Results.DataGrids[ii]))
+        data.append(unpack_datagrid(analysis.Results.DataGrids[ii],
+                                    # pass "center" and None for consistency with older ZOSPy versions
+                                     cell_origin="center", label_rounding=None))
 
     if len(data) == 0:
         data = pd.DataFrame()

--- a/zospy/utils/zputils.py
+++ b/zospy/utils/zputils.py
@@ -91,9 +91,10 @@ def unpack_dataseries(dataseries: _ZOSAPI.Analysis.Data.IAR_DataSeries) -> pd.Da
 
 def unpack_datagrid(
     datagrid: _ZOSAPI.Analysis.Data.IAR_DataGrid,
-    minx=None,
-    miny=None,
+    minx: float | None = None,
+    miny: float | None = None,
     cell_origin: Literal["bottom_left", "center"] = "bottom_left",
+    label_rounding: int | None = 10,
 ) -> pd.DataFrame:
     """Unpack an OpticStudio datagrid to a Pandas DataFrame.
 
@@ -109,6 +110,9 @@ def unpack_datagrid(
         Defines how minx and miny are handled to determine coordinates. Either 'bottom_left' indicating that they are
         defining the bottom left of the grd cell, or 'center', indicating that they provide the center of the grid cell.
         Defaults to 'bottom_left'.
+    label_rounding : Optional[int]
+        Defines the numbers of decimals to which the column and index labels are rounded. If set to None, no rounding is
+        applied. Defaults to 10.
 
     Returns
     -------
@@ -129,8 +133,12 @@ def unpack_datagrid(
     else:
         raise ValueError(f"Cannot process the cell origin '{cell_origin}'")
 
-    columns = np.linspace(minx, minx + datagrid.Dx * (datagrid.Nx - 1), datagrid.Nx).round(10)
-    rows = np.linspace(miny, miny + datagrid.Dy * (datagrid.Ny - 1), datagrid.Ny).round(10)
+    columns = np.linspace(minx, minx + datagrid.Dx * (datagrid.Nx - 1), datagrid.Nx)
+    rows = np.linspace(miny, miny + datagrid.Dy * (datagrid.Ny - 1), datagrid.Ny)
+
+    if label_rounding is not None:
+        columns = columns.round(label_rounding)
+        rows = rows.round(label_rounding)
 
     df = pd.DataFrame(data=values, index=rows, columns=columns)
     df.index.name = datagrid.YLabel or "y"


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->
`ZOSPy` 2.0 has a slightly different way of labeling datagrid columns and indices, as implemented `unpack_datagrid` in #128. The analyses in `analyses.old` use the same `unpack_datagrid` as the new analyses and thus get the same labelling behaviour. As a result, the results of the current old analyses are not in line with the actual old analyses anymore. This also causes some unit tests for the old tests to fail.

While we do not really update the old analyses anymore, I think we should try to keep them equal. This requires two things:
1. Always passing `cell_origin="center"` to `unpack_datagrid`, as that essentially gives the old behaviour
2. Not rounding the column and indices labels in `unpack_datagrid`. To that end, I introduced the argument `label_rounding`, which specifies the decimals to which the labels are rounded. It defaults to 10 (the current rounding implementation), but als oaccepts None, which will result in no rounding. In the old analyses, `label_rounding=None` is now passed.


## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.11
- OpticStudio version: 20.3.2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [ ] I have followed the [contribution guidelines][contribution-guidelines]
- [ ] The code has been linted, formatted and tested locally using hatch.
- [ ] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
