### PR TITLE
Added tests for HuygensPSF

### DIFF
--- a/scripts/generate_test_reference_data/tests.yaml
+++ b/scripts/generate_test_reference_data/tests.yaml
@@ -130,10 +130,54 @@ tests:
     analysis: psf.HuygensPSF
     file: test_psf.py
     test: test_huygens_psf_returns_correct_result
+    parametrized: [pupil_sampling, image_sampling, image_delta, psf_type, normalize]
+    parameters:
+      - pupil_sampling: 64x64
+        image_sampling: 64x64
+        image_delta: 0.0
+        psf_type: Linear
+        normalize: false
+      - pupil_sampling: 32x32
+        image_sampling: 64x64
+        image_delta: 1.0
+        psf_type: Linear
+        normalize: false
+      - pupil_sampling: 128x128
+        image_sampling: 128x128
+        image_delta: 0.0
+        psf_type: Real
+        normalize: true
+      - pupil_sampling: 32x32
+        image_sampling: 32x32
+        image_delta: 0.0
+        psf_type: Real
+        normalize: true
   - model: decentered_system
     analysis: psf.HuygensPSF
     file: test_psf.py
     test: test_huygens_psf_asymmetric_returns_correct_result
+    parametrized: [pupil_sampling, image_sampling, image_delta, psf_type, normalize]
+    parameters:
+      - pupil_sampling: 64x64
+        image_sampling: 64x64
+        image_delta: 0.0
+        psf_type: Linear
+        normalize: false
+      - pupil_sampling: 32x32
+        image_sampling: 64x64
+        image_delta: 1.0
+        psf_type: Linear
+        normalize: false
+      - pupil_sampling: 128x128
+        image_sampling: 128x128
+        image_delta: 0.0
+        psf_type: Real
+        normalize: true
+      - pupil_sampling: 32x32
+        image_sampling: 32x32
+        image_delta: 0.0
+        psf_type: Real
+        normalize: true
   - model: simple_system
     analysis: raysandspots.SingleRayTrace
     file: test_raysandspots.py

--- a/tests/analyses/test_psf.py
+++ b/tests/analyses/test_psf.py
@@ -1,0 +1,102 @@
+import pytest
+from pandas.testing import assert_frame_equal
+
+from zospy.analyses.psf import HuygensPSF
+
+
+class TestHuygensPSF:
+    def test_can_run(self, simple_system):
+        result = HuygensPSF().run(simple_system)
+        assert result.data is not None
+
+    def test_to_json(self, simple_system):
+        result = HuygensPSF().run(simple_system)
+        assert result.from_json(result.to_json()).to_json() == result.to_json()
+
+    @pytest.mark.parametrize(
+        "pupil_sampling,image_sampling,image_delta,psf_type,normalize",
+        [
+            ("64x64", "64x64", 0.0, "Linear", False),
+            ("32x32", "64x64", 1.0, "Linear", False),
+            ("128x128", "128x128", 0.0, "Real", True),
+            ("32x32", "32x32", 0.0, "Real", True),
+        ],
+    )
+    def test_huygens_psf_returns_correct_result(
+        self, simple_system, pupil_sampling, image_sampling, image_delta, psf_type, normalize, expected_data
+    ):
+        result = HuygensPSF(
+            pupil_sampling=pupil_sampling,
+            image_sampling=image_sampling,
+            image_delta=image_delta,
+            psf_type=psf_type,
+            normalize=normalize,
+        ).run(simple_system)
+
+        assert_frame_equal(result.data, expected_data.data)
+
+    @pytest.mark.parametrize(
+        "pupil_sampling,image_sampling,image_delta,psf_type,normalize",
+        [
+            ("64x64", "64x64", 0.0, "Linear", False),
+            ("32x32", "64x64", 1.0, "Linear", False),
+            ("128x128", "128x128", 0.0, "Real", True),
+            ("32x32", "32x32", 0.0, "Real", True),
+        ],
+    )
+    def test_huygens_psf_matches_reference_data(
+        self, simple_system, pupil_sampling, image_sampling, image_delta, psf_type, normalize, reference_data
+    ):
+        result = HuygensPSF(
+            pupil_sampling=pupil_sampling,
+            image_sampling=image_sampling,
+            image_delta=image_delta,
+            psf_type=psf_type,
+            normalize=normalize,
+        ).run(simple_system)
+
+        assert_frame_equal(result.data, reference_data.data)
+
+    @pytest.mark.parametrize(
+        "pupil_sampling,image_sampling,image_delta,psf_type,normalize",
+        [
+            ("64x64", "64x64", 0.0, "Linear", False),
+            ("32x32", "64x64", 1.0, "Linear", False),
+            ("128x128", "128x128", 0.0, "Real", True),
+            ("32x32", "32x32", 0.0, "Real", True),
+        ],
+    )
+    def test_huygens_psf_asymmetric_returns_correct_result(
+        self, decentered_system, pupil_sampling, image_sampling, image_delta, psf_type, normalize, expected_data
+    ):
+        result = HuygensPSF(
+            pupil_sampling=pupil_sampling,
+            image_sampling=image_sampling,
+            image_delta=image_delta,
+            psf_type=psf_type,
+            normalize=normalize,
+        ).run(decentered_system)
+
+        assert_frame_equal(result.data, expected_data.data)
+
+    @pytest.mark.parametrize(
+        "pupil_sampling,image_sampling,image_delta,psf_type,normalize",
+        [
+            ("64x64", "64x64", 0.0, "Linear", False),
+            ("32x32", "64x64", 1.0, "Linear", False),
+            ("128x128", "128x128", 0.0, "Real", True),
+            ("32x32", "32x32", 0.0, "Real", True),
+        ],
+    )
+    def test_huygens_psf_asymmetric_matches_reference_data(
+        self, decentered_system, pupil_sampling, image_sampling, image_delta, psf_type, normalize, reference_data
+    ):
+        result = HuygensPSF(
+            pupil_sampling=pupil_sampling,
+            image_sampling=image_sampling,
+            image_delta=image_delta,
+            psf_type=psf_type,
+            normalize=normalize,
+        ).run(decentered_system)
+
+        assert_frame_equal(result.data, reference_data.data)


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->
I added tests for the `HuygensPSF` analysis.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which versions of Python and OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
  
  Please list all Python versions you used to test your changes. The unit tests will
  automatically try to test all currently supported Python versions. If you would like
  to do us a favor, install all necessary Python versions on your system. This helps
  us to ensure compatibility and detect any problems we might not be able to detect
  on our own systems. This makes your contribution even more valuable!
-->

- Python version: 3.11
- OpticStudio version: 20.3.2

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->
#133 

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested locally using hatch.
- [ ] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.** --> the reference data is still to be generated
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    This is important, because it allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/CONTRIBUTING.md
[unittest-instructions]: https://github.com/MREYE-LUMC/ZOSPy/blob/main/tests/README.md
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
