### PR TITLE
Use ZOS.get_instance in copy_system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ ZOS-API can also be added in patch releases.
 
 ### Fixed
 
+- `OpticStudioSystem.copy_system` now uses `ZOS.get_instance` instead of an internal weak reference (#149)
+
 ### Deprecated
 
 ### Removed

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -160,6 +160,17 @@ class TestSaveAs:
         assert save_path.exists()
 
 
+def test_copy_system(simple_system):
+    # Copy the system
+    copied_system = simple_system.copy_system()
+
+    assert copied_system.SystemID != simple_system.SystemID
+    assert copied_system.LDE.NumberOfSurfaces == 5
+
+    # Check that the copied system is a different object
+    assert copied_system is not simple_system
+
+
 def test_get_system(zos, oss, connection_mode):
     if connection_mode == "extension":
         pytest.xfail(reason="GetSystem does not work correctly in extension mode due to a bug in the ZOS-API.")

--- a/tests/test_zpcore.py
+++ b/tests/test_zpcore.py
@@ -1,4 +1,6 @@
 import locale
+import re
+import weakref
 from pathlib import Path
 from sys import version_info
 from types import SimpleNamespace
@@ -7,6 +9,7 @@ import pytest
 
 import zospy as zp
 from zospy import constants
+from zospy.zpcore import OpticStudioSystem
 
 # ruff: noqa: SLF001
 
@@ -88,6 +91,17 @@ def test_get_primary_system_populates_openfile(zos, oss):  # noqa: ARG001
 @pytest.mark.must_pass
 def test_create_simple_system(simple_system):
     assert simple_system.LDE.NumberOfSurfaces == 5
+
+
+def test_oss_constructor_weakref_zos_raises_typeerror(zos):
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "zos_instance must be a ZOS instance, but a weak reference is passed. Use "
+            "ZOS.get_instance() to get the current ZOS instance."
+        ),
+    ):
+        OpticStudioSystem(weakref.proxy(zos), None)
 
 
 def test_version(optic_studio_version):

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -44,17 +44,28 @@ logger = logging.getLogger(__name__)
 class OpticStudioSystem:
     """Wrapper for OpticStudio System instances."""
 
-    def __init__(self, zos_instance, system_instance):
+    def __init__(self, zos_instance: ZOS, system_instance: _ZOSAPI.IOpticalSystem):
         """Initiate the OpticStudioSystem.
 
         Parameters
         ----------
         zos_instance : ZOS
             A ZOS instance
-        system_instance : ZOS.Application.PrimarySystem
-            A PrimarySystem instance obtained from the zos_instance.
+        system_instance : ZOSAPI.IOpticalSystem
+            An optical system obtained from the ZOS instance.
+
+        Raises
+        ------
+        TypeError
+            If a weak reference to the ZOS instance is passed instead of the instance itself.
         """
-        # Use weakref to make sure that the ZOS instance is not kept alive by the OpticStudioSystem instance
+        if isinstance(zos_instance, weakref.ProxyType):
+            raise TypeError(
+                "zos_instance must be a ZOS instance, but a weak reference is passed. Use "
+                "ZOS.get_instance() to get the current ZOS instance."
+            )
+
+        # Use weak reference to make sure that the ZOS instance is not kept alive by the OpticStudioSystem instance
         self.ZOS: ZOS = weakref.proxy(zos_instance)
 
         self._System: _ZOSAPI.IOpticalSystem = system_instance

--- a/zospy/zpcore.py
+++ b/zospy/zpcore.py
@@ -311,7 +311,7 @@ class OpticStudioSystem:
         zospy.zpcore.OpticStudioSystem
             A ZOSPy OpticStudioSystem instance. Should be sequential.
         """
-        return OpticStudioSystem(self.ZOS, self._System.CopySystem())
+        return OpticStudioSystem(ZOS.get_instance(), self._System.CopySystem())
 
     def _ensure_correct_mode(self, required: str):
         """Ensure that the system is in the required type.


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

Passing self.ZOS fails because it tries to create a weak reference to a weak reference. Use ZOS.get_instance instead. See #148 

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which version of OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
-->

- OpticStudio version: 25R1

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

Closes #148 

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested (see the [contribution guidelines][code-style-guidelines]).
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I tested ZOSPy for _all_ supported Python versions (`hatch test -a`).
- [x] I added new tests for any features contributed, or updated existing tests.
- [x] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you updated an example:

- [ ] I executed all examples and verified that they run without errors (`hatch run all-examples`).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    Examples must be supplied as Jupyter notebooks, because this allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html
[code-style-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html#workflow
[unittest-instructions]: https://zospy.readthedocs.io/en/latest/contributing/unit_tests.html
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
