### PR TITLE
Fix workflows being triggered twice in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,27 @@ name: Continuous Integration
 
 on:
   - push
-  - pull_request
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build ZOSPy
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up uv
-      id: setup-uv
-      uses: astral-sh/setup-uv@v3
-    - name: Build package
-      run: uv build --python ${{ matrix.python }}
-    - name: Install package
-      run: uv venv --python ${{ matrix.python }} && uv pip install --find-links ./dist/ zospy
+      - uses: actions/checkout@v4
+      - name: Set up uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v3
+      - name: Build package
+        run: uv build --python ${{ matrix.python }}
+      - name: Install package
+        run: uv venv --python ${{ matrix.python }} && uv pip install --find-links ./dist/ zospy
 
   lint:
     runs-on: ubuntu-latest
+    name: Lint ZOSPy
     steps:
       - uses: actions/checkout@v4
       - name: Set up uv
@@ -34,21 +35,3 @@ jobs:
         if: always() # Run even if previous step fails
         run: |
           uvx pydocstringformatter --exit-code examples scripts tests zospy
-
-  check_file_updates:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip changelog')
-    name: Check CHANGELOG.md for updates
-    steps:
-        - uses: actions/checkout@v4
-        - name: Check for CHANGELOG.md updates
-          run: |
-            git fetch
-            FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
-            for i in $FILES_CHANGED
-            do
-              if [[ "$i" == "CHANGELOG.md" ]]
-              then
-                exit 0
-              fi
-            done

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,22 @@
+name: pr.yml
+on:
+  - pull_request
+
+jobs:
+  check_file_updates:
+    runs-on: ubuntu-latest
+    if: !contains(github.event.pull_request.labels.*.name, 'skip changelog')
+    name: Check CHANGELOG.md for updates
+    steps:
+        - uses: actions/checkout@v4
+        - name: Check for CHANGELOG.md updates
+          run: |
+            git fetch
+            FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }})
+            for i in $FILES_CHANGED
+            do
+              if [[ "$i" == "CHANGELOG.md" ]]
+              then
+                exit 0
+              fi
+            done


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

The workflow in `ci.yml` triggered both on `push` and `pull_request` events, causing it to be triggered twice in pull requests.
The only job that really needed to be triggered by pull requests is the changelog check; for the other jobs, triggering on push is sufficient. I moved the changelog check to a separate workflow that only runs on pull requests and changed `ci.yml` to only run on push.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which version of OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
-->

- OpticStudio version: N/A

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [ ] The code has been linted, formatted and tested (see the [contribution guidelines][code-style-guidelines]).
- [ ] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I tested ZOSPy for _all_ supported Python versions (`hatch test -a`).
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you updated an example:

- [ ] I executed all examples and verified that they run without errors (`hatch run all-examples`).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    Examples must be supplied as Jupyter notebooks, because this allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html
[code-style-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html#workflow
[unittest-instructions]: https://zospy.readthedocs.io/en/latest/contributing/unit_tests.html
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
