### PR TITLE
Manage version through versioningit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "versioningit"]
 build-backend = "hatchling.build"
 
 [project]
@@ -51,7 +51,8 @@ docs = [
 ### Hatch configuration
 
 [tool.hatch.version]
-path = "zospy/__init__.py"
+source = "versioningit"
+default-version = "0.0.0+unknown"
 
 [tool.hatch.envs.default]
 python = "3.12"

--- a/zospy/__init__.py
+++ b/zospy/__init__.py
@@ -1,14 +1,13 @@
 """Communicate with OpticStudio through the ZOS-API."""
 
-__version__ = "2.0.2"
-
 import logging
+from importlib.metadata import version
 
 from zospy import analyses, functions, solvers
 from zospy.api import config, constants
 from zospy.zpcore import ZOS
 
-config.set_decimal_point_and_thousands_separator()
+__version__ = version("zospy")
 
 __all__ = (
     "analyses",
@@ -18,4 +17,5 @@ __all__ = (
     "ZOS",
 )
 
+config.set_decimal_point_and_thousands_separator()
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
I noticed the release of ZOSPy 2.1.0 to PyPI failed because I didn't update the version number. I changed the project configuration to manage package versions with versioningit, which prevents this problem from happening in the future (visisipy already uses this and it works quite well). 