### PR TITLE
Support ZOSPy constants for Huygens PSF

### DIFF
--- a/zospy/analyses/psf/huygens_psf.py
+++ b/zospy/analyses/psf/huygens_psf.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from zospy.analyses.base import BaseAnalysisWrapper
 from zospy.analyses.decorators import analysis_settings
-from zospy.analyses.parsers.types import FieldNumber, WavelengthNumber  # noqa: TCH001
+from zospy.analyses.parsers.types import FieldNumber, WavelengthNumber, ZOSAPIConstant  # noqa: TCH001
 from zospy.api import constants
 from zospy.utils.zputils import standardize_sampling
 
@@ -55,8 +55,8 @@ class HuygensPSFSettings:
     rotation: Literal[0, 90, 180, 270] = Field(default=0, description="Rotation")
     wavelength: WavelengthNumber = Field(default="All", description="Wavelength number or 'All'")
     field: FieldNumber = Field(default=1, description="Field number or 'All'")
-    psf_type: str = Field(default="Linear", description="PSF type")
-    show_as: str = Field(default="Surface", description="Show as")
+    psf_type: ZOSAPIConstant("Analysis.Settings.HuygensPsfTypes") = Field(default="Linear", description="PSF type")
+    show_as: ZOSAPIConstant("Analysis.HuygensShowAsTypes") = Field(default="Surface", description="Show as")
     use_polarization: bool = Field(default=False, description="Use polarization")
     use_centroid: bool = Field(default=False, description="Use centroid")
     normalize: bool = Field(default=False, description="Normalize")


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->

Improve the type hints for the Huygens PSF analysis. The settings class previously only accepted strings, now ZOSAPI constants are accepted as well.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which version of OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
-->

- OpticStudio version: 25R1

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [x] The code has been linted, formatted and tested (see the [contribution guidelines][code-style-guidelines]).
- [x] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [x] I tested ZOSPy for _all_ supported Python versions (`hatch test -a`).
- [x] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you updated an example:

- [ ] I executed all examples and verified that they run without errors (`hatch run all-examples`).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    Examples must be supplied as Jupyter notebooks, because this allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html
[code-style-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html#workflow
[unittest-instructions]: https://zospy.readthedocs.io/en/latest/contributing/unit_tests.html
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
