### PR TITLE
Fix Huygens PSF typing

### DIFF
--- a/tests/analyses/test_analysis_settings.py
+++ b/tests/analyses/test_analysis_settings.py
@@ -4,12 +4,14 @@ from inspect import getsource
 import pytest
 
 from zospy.analyses.base import BaseAnalysisWrapper, new_analysis
+from zospy.analyses.psf.huygens_psf import BaseHuygensPSF
 from zospy.analyses.systemviewers.base import SystemViewerWrapper
 from zospy.api import constants
 from zospy.api.constants import process_constant
 
 analysis_wrapper_classes = BaseAnalysisWrapper.__subclasses__()
 analysis_wrapper_classes.remove(SystemViewerWrapper)
+analysis_wrapper_classes.remove(BaseHuygensPSF)
 
 REGEX_SETTING = re.compile(r"\s*self\.analysis\.Settings\.(?P<setting>\w+)")
 
@@ -19,7 +21,10 @@ def test_settings_exist(empty_system, analysis_wrapper):
     if analysis_wrapper.MODE == "Nonsequential":
         empty_system.make_nonsequential()
 
-    analysis = new_analysis(empty_system, process_constant(constants.Analysis.AnalysisIDM, analysis_wrapper.TYPE))
+    analysis = new_analysis(
+        empty_system,
+        process_constant(constants.Analysis.AnalysisIDM, analysis_wrapper.TYPE),
+    )
     source = getsource(analysis_wrapper.run_analysis)
 
     settings = REGEX_SETTING.findall(source)

--- a/tests/analyses/test_base.py
+++ b/tests/analyses/test_base.py
@@ -26,6 +26,7 @@ from zospy.analyses.base import (
 )
 from zospy.analyses.decorators import analysis_settings
 from zospy.analyses.parsers.types import ValidatedDataFrame
+from zospy.analyses.psf.huygens_psf import BaseHuygensPSF
 from zospy.analyses.reports.surface_data import SurfaceDataSettings
 from zospy.analyses.systemviewers.base import SystemViewerWrapper
 
@@ -36,6 +37,7 @@ def all_subclasses(cls):
 
 analysis_wrapper_classes = all_subclasses(BaseAnalysisWrapper)
 analysis_wrapper_classes.remove(SystemViewerWrapper)
+analysis_wrapper_classes.remove(BaseHuygensPSF)
 
 
 class TestValidatedSetter:

--- a/zospy/analyses/psf/huygens_psf.py
+++ b/zospy/analyses/psf/huygens_psf.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import re
-from typing import Annotated, Literal, Union
+from abc import ABC
+from typing import Annotated, Generic, Literal, Union
 
 from pandas import DataFrame
 from pydantic import Field
 
-from zospy.analyses.base import BaseAnalysisWrapper
+from zospy.analyses.base import AnalysisData, BaseAnalysisWrapper
 from zospy.analyses.decorators import analysis_result, analysis_settings
 from zospy.analyses.parsers.types import (  # noqa: TCH001
     FieldNumber,
@@ -75,8 +76,8 @@ class HuygensPSFSettings:
     normalize: bool = Field(default=False, description="Normalize")
 
 
-class HuygensPSF(BaseAnalysisWrapper[Union[DataFrame, None], HuygensPSFSettings], analysis_type="HuygensPsf"):
-    """Huygens Point Spread Function (PSF) analysis."""
+class BaseHuygensPSF(BaseAnalysisWrapper[AnalysisData, HuygensPSFSettings], ABC, Generic[AnalysisData]):
+    """Base class for Huygens Point Spread Function (PSF) analyses."""
 
     def __init__(
         self,
@@ -131,7 +132,11 @@ class HuygensPSF(BaseAnalysisWrapper[Union[DataFrame, None], HuygensPSFSettings]
         return self.get_data_grid(cell_origin="bottom_left")
 
 
-class HuygensPSFAndStrehlRatio(HuygensPSF, needs_text_output_file=True, analysis_type="HuygensPsf"):
+class HuygensPSF(BaseHuygensPSF[Union[DataFrame, None]], analysis_type="HuygensPsf"):
+    """Huygens Point Spread Function (PSF) analysis."""
+
+
+class HuygensPSFAndStrehlRatio(BaseHuygensPSF[HuygensPSFData], needs_text_output_file=True, analysis_type="HuygensPsf"):
     """Huygens Point Spread Function (PSF) analysis with Strehl ratio."""
 
     RE_STREHL_RATIO = re.compile(r"^\s*Strehl ratio\s*:\s*(\d+[.,]?\d*)\s*$", re.IGNORECASE | re.MULTILINE)

--- a/zospy/analyses/psf/huygens_psf.py
+++ b/zospy/analyses/psf/huygens_psf.py
@@ -25,7 +25,7 @@ __all__ = ("HuygensPSF", "HuygensPSFAndStrehlRatio", "HuygensPSFSettings")
 
 
 @analysis_result
-class HuygensPSFData:
+class HuygensPSFResult:
     psf: ValidatedDataFrame
     strehl_ratio: float
 
@@ -136,7 +136,7 @@ class HuygensPSF(BaseHuygensPSF[Union[DataFrame, None]], analysis_type="HuygensP
     """Huygens Point Spread Function (PSF) analysis."""
 
 
-class HuygensPSFAndStrehlRatio(BaseHuygensPSF[HuygensPSFData], needs_text_output_file=True, analysis_type="HuygensPsf"):
+class HuygensPSFAndStrehlRatio(BaseHuygensPSF[HuygensPSFResult], needs_text_output_file=True, analysis_type="HuygensPsf"):
     """Huygens Point Spread Function (PSF) analysis with Strehl ratio."""
 
     RE_STREHL_RATIO = re.compile(r"^\s*Strehl ratio\s*:\s*(\d+[.,]?\d*)\s*$", re.IGNORECASE | re.MULTILINE)
@@ -150,9 +150,9 @@ class HuygensPSFAndStrehlRatio(BaseHuygensPSF[HuygensPSFData], needs_text_output
 
         raise RuntimeError("Could not extract Strehl ratio from Huygens PSF output.")
 
-    def run_analysis(self) -> HuygensPSFData:
+    def run_analysis(self) -> HuygensPSFResult:
         """Run the Huygens PSF and Strehl Ratio analysis."""
         psf_data = super().run_analysis()
         strehl_ratio = self.get_strehl_ratio()
 
-        return HuygensPSFData(psf=psf_data, strehl_ratio=strehl_ratio)
+        return HuygensPSFResult(psf=psf_data, strehl_ratio=strehl_ratio)


### PR DESCRIPTION
The previous implementation resulted in incorrect autocompletions for the `HuygensPSFAndStrehlRatio` analysis, which negatively impacted the developer experience. By splitting the common logic to a separate base class, it is possible to have correct annotation on both classes, resulting in better autocompletions.