### PR TITLE
Updated doc to specify that None constants are implemented as None_

### DIFF
--- a/docs/usage/04_constants.md
+++ b/docs/usage/04_constants.md
@@ -14,3 +14,7 @@ zos = zp.ZOS() # <-- Constants are only available after creating a ZOS instance
 
 print(zp.constants.Editors.LDE.SurfaceType.Standard)
 ```
+
+Note that OpticStudio `None` constants have been implemented as `None_` since `None` is a Python keyword.
+
+For example, the `LensUpdateMode.None` constant is available as `LensUpdateMode.None_`.


### PR DESCRIPTION
<!--
  Thanks a lot for contributing to our project!
  Please, do not remove any text from this template (unless instructed otherwise).
-->

## Proposed change
<!--
  What did you change and why did you change it?
-->
Updated documentation to specify that enumerations with `None` constants have been implemented as `None_` due to Python restrictions.

## Type of change
<!--
  What type of change does your PR introduce to ZOSPy?
-->

- [ ] Example (a notebook demonstrating how to use ZOSPy for a specific application)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New analysis (a wrapper around an OpticStudio analysis)
- [ ] New feature (other than an analysis)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Documentation (improvement of either the docstrings or the documentation website)

# Additional information
<!--
  We would like to know which version of OpticStudio you are running.
  This helps us to keep the compatibility section in our documentation updated.
-->

- OpticStudio version: 2025 R1.00

## Related issues
<!--
  Please list any issues, discussions or pull requests related to this pull request.
-->
[175](https://github.com/MREYE-LUMC/ZOSPy/issues/175)

## Checklist
<!--
  Tick all boxes that apply. 
-->

- [x] I have followed the [contribution guidelines][contribution-guidelines]
- [ ] The code has been linted, formatted and tested (see the [contribution guidelines][code-style-guidelines]).
- [ ] Local tests pass. **Please fix any problems before opening a PR. If this is not possible, specify what doesn't work and why you can't fix it.**
- [ ] I tested ZOSPy for _all_ supported Python versions (`hatch test -a`).
- [ ] I added new tests for any features contributed, or updated existing tests.
- [ ] I updated CHANGELOG.md with my changes (except for refactorings and changes in the documentation).

If you updated an example:

- [ ] I executed all examples and verified that they run without errors (`hatch run all-examples`).

If you contributed an example:

- [ ] I contributed my example as a Jupyter notebook.
    <!--
    Examples must be supplied as Jupyter notebooks, because this allows users to see the results without
    executing the complete example.
    -->

<!--
  Thanks again for your contribution! We will look into it soon.
  Meanwhile, here are some useful resources that will help you to improve
  the quality of your contribution:
-->
[contribution-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html
[code-style-guidelines]: https://zospy.readthedocs.io/en/latest/contributing/contributing.html#workflow
[unittest-instructions]: https://zospy.readthedocs.io/en/latest/contributing/unit_tests.html
[numpydoc]: https://numpydoc.readthedocs.io/en/latest/format.html
